### PR TITLE
feat: land design system across all pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,12 +1,14 @@
 import Image from 'next/image'
 import { PortableText } from '@portabletext/react'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor } from '@/sanity/lib/image'
+import { urlFor, hasAsset } from '@/sanity/lib/image'
+import SiteFooter from '../components/site-footer'
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
   title,
   subtitle,
   mainImage,
+  introShort,
   introLong
 }`
 
@@ -29,14 +31,20 @@ const portableTextComponents = {
       <p className="mb-4 leading-relaxed text-white/80">{children}</p>
     ),
     h2: ({ children }: { children?: React.ReactNode }) => (
-      <h2 className="mt-10 mb-3 text-xl md:text-2xl font-medium">{children}</h2>
+      <h2 className="mt-10 mb-3 text-xl md:text-2xl font-medium text-white">
+        {children}
+      </h2>
     ),
     h3: ({ children }: { children?: React.ReactNode }) => (
-      <h3 className="mt-8 mb-2 text-lg md:text-xl font-medium">{children}</h3>
+      <h3 className="mt-8 mb-2 text-lg md:text-xl font-medium text-white">
+        {children}
+      </h3>
     ),
     blockquote: ({ children }: { children?: React.ReactNode }) => (
-      <blockquote className="my-6 border-l-2 border-white/20 pl-4 italic text-white/70">
-        {children}
+      <blockquote className="my-8 border-l-2 border-white/30 pl-5 italic">
+        <span className="text-gradient-pink-blue text-xl md:text-2xl font-medium leading-snug">
+          {children}
+        </span>
       </blockquote>
     ),
   },
@@ -70,40 +78,66 @@ export default async function AboutPage() {
   const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
 
   return (
-    <div className="pt-16 md:pt-24">
-      <h1>About</h1>
-
-      <div className="mt-12 grid grid-cols-1 items-start gap-8 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] md:gap-12 lg:gap-16">
-        {/* Image */}
-        {general?.mainImage && (
-          <div className="relative aspect-[3/4] w-full max-w-md md:max-w-none">
-            <Image
-              src={urlFor(general.mainImage).width(900).url()}
-              alt={general.mainImage.alt ?? ''}
-              fill
-              sizes="(min-width: 768px) 40vw, 90vw"
-              className="object-cover"
-            />
+    <div className="flex flex-col">
+      {/* Hero */}
+      <section className="pt-16 md:pt-24">
+        <div className="flex items-end justify-between gap-4">
+          <p className="display-section">About</p>
+          <div className="label-role flex gap-3 pb-2 md:pb-4">
+            <span>SINGER</span>
+            <span aria-hidden="true">•</span>
+            <span>SONGWRITER</span>
           </div>
-        )}
-
-        {/* Text */}
-        <div className="md:max-w-prose">
-          {general?.title && (
-            <p className="mb-6 text-xs uppercase tracking-widest text-white/60">
-              {general.title}
-            </p>
-          )}
-          {general?.introLong ? (
-            <PortableText
-              value={general.introLong}
-              components={portableTextComponents}
-            />
-          ) : (
-            <p className="text-sm text-white/60">No bio yet.</p>
-          )}
         </div>
-      </div>
+        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
+          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
+            ABOUT
+          </span>
+          <span
+            className="display-giant display-giant--xl reflect whitespace-nowrap"
+            aria-hidden="true"
+          >
+            ABOUT
+          </span>
+        </div>
+      </section>
+
+      {/* Content */}
+      <section className="mt-12 md:mt-20">
+        <div className="grid grid-cols-1 items-start gap-10 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] md:gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-20">
+          {hasAsset(general?.mainImage) && (
+            <div className="relative aspect-[3/4] w-full max-w-md md:max-w-none md:sticky md:top-8">
+              <Image
+                src={urlFor(general.mainImage).width(1000).url()}
+                alt={general.mainImage.alt ?? ''}
+                fill
+                sizes="(min-width: 1024px) 40vw, (min-width: 768px) 40vw, 90vw"
+                className="object-cover mix-blend-lighten"
+              />
+            </div>
+          )}
+
+          <div>
+            {general?.title && (
+              <p className="label-role mb-6">{general.title}</p>
+            )}
+            {general?.introLong ? (
+              <PortableText
+                value={general.introLong}
+                components={portableTextComponents}
+              />
+            ) : general?.introShort ? (
+              <p className="body-text text-white/80 md:text-lg md:leading-relaxed">
+                {general.introShort}
+              </p>
+            ) : (
+              <p className="text-sm text-white/60">No bio yet.</p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <SiteFooter wordmark="ADEOLA" />
     </div>
   )
 }

--- a/app/audio/page.tsx
+++ b/app/audio/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor } from '@/sanity/lib/image'
+import { urlFor, hasAsset } from '@/sanity/lib/image'
+import SiteFooter from '../components/site-footer'
 
 type Track = {
   _id: string
@@ -20,60 +21,93 @@ const AUDIO_QUERY = `*[_type == "audio"] | order(_createdAt desc){
 
 export default async function AudioPage() {
   const { data: tracks } = await sanityFetch({ query: AUDIO_QUERY })
+  const trackList: Track[] = tracks ?? []
 
   return (
-    <div className="pt-16 md:pt-24">
-      <h1>Audio</h1>
+    <div className="flex flex-col">
+      {/* Hero */}
+      <section className="pt-16 md:pt-24">
+        <div className="flex items-start gap-2 leading-none">
+          <p className="display-section">Audio</p>
+          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
+            ({trackList.length})
+          </span>
+        </div>
+        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
+          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
+            AUDIO
+          </span>
+          <span
+            className="display-giant display-giant--xl reflect whitespace-nowrap"
+            aria-hidden="true"
+          >
+            AUDIO
+          </span>
+        </div>
+      </section>
 
-      {tracks && tracks.length > 0 ? (
-        <div className="mt-12 flex flex-col gap-10 md:max-w-3xl">
-          {tracks.map((track: Track) => (
-            <div
-              key={track._id}
-              className="flex flex-col gap-4 border-t border-white/10 pt-6 md:pt-8"
-            >
-              <div className="flex items-start gap-4 md:gap-6">
-                {track.coverImage ? (
-                  <div className="relative h-20 w-20 shrink-0 md:h-28 md:w-28 lg:h-32 lg:w-32">
-                    <Image
-                      src={urlFor(track.coverImage).width(400).url()}
-                      alt={track.coverImage.alt ?? track.title}
-                      fill
-                      sizes="(min-width: 1024px) 128px, (min-width: 768px) 112px, 80px"
-                      className="object-cover"
-                    />
+      {/* Tracks */}
+      <section className="mt-12 md:mt-20">
+        {trackList.length > 0 ? (
+          <div className="flex flex-col">
+            {trackList.map((track) => (
+              <article
+                key={track._id}
+                className="flex flex-col gap-5 border-t border-white/20 py-6 md:flex-row md:items-center md:gap-8 md:py-8"
+              >
+                <div className="flex items-center gap-5 md:gap-6 md:flex-1">
+                  {hasAsset(track.coverImage) ? (
+                    <div className="relative h-20 w-20 shrink-0 md:h-24 md:w-24 lg:h-28 lg:w-28">
+                      <Image
+                        src={urlFor(track.coverImage).width(400).url()}
+                        alt={track.coverImage.alt ?? track.title}
+                        fill
+                        sizes="(min-width: 1024px) 112px, (min-width: 768px) 96px, 80px"
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-20 w-20 shrink-0 bg-white/5 md:h-24 md:w-24 lg:h-28 lg:w-28" />
+                  )}
+                  <div className="flex flex-col gap-1">
+                    <p className="text-lg md:text-xl font-bold uppercase tracking-widest text-white">
+                      {track.title}
+                    </p>
+                    {track.subtitle && (
+                      <p className="text-sm tracking-wide text-white/60 md:text-base">
+                        {track.subtitle}
+                      </p>
+                    )}
                   </div>
-                ) : (
-                  <div className="h-20 w-20 shrink-0 bg-white/5 md:h-28 md:w-28 lg:h-32 lg:w-32" />
-                )}
-                <div className="flex flex-col gap-1 pt-1">
-                  <p className="text-base md:text-lg font-medium">
-                    {track.title}
-                  </p>
-                  {track.subtitle && (
-                    <p className="text-sm text-white/60">{track.subtitle}</p>
+                </div>
+
+                <div className="md:flex-1 md:max-w-md">
+                  {track.audio?.asset?.url ? (
+                    <div className="bg-white/5 p-2 rounded-full">
+                      <audio
+                        controls
+                        src={track.audio.asset.url}
+                        aria-label={`Play ${track.title}`}
+                        className="h-10 w-full"
+                      />
+                    </div>
+                  ) : (
+                    <p className="text-sm text-white/40">
+                      No audio file uploaded.
+                    </p>
                   )}
                 </div>
-              </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="border-t border-white/20 pt-5 text-sm text-white/60">
+            No tracks yet.
+          </p>
+        )}
+      </section>
 
-              {track.audio?.asset?.url ? (
-                <audio
-                  controls
-                  src={track.audio.asset.url}
-                  aria-label={`Play ${track.title}`}
-                  className="h-10 w-full opacity-80"
-                />
-              ) : (
-                <p className="text-sm text-white/60">No audio file uploaded.</p>
-              )}
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p className="mt-12 border-t border-white/10 pt-5 text-sm text-white/60">
-          No tracks yet.
-        </p>
-      )}
+      <SiteFooter wordmark="AUDIO" />
     </div>
   )
 }

--- a/app/components/cta.tsx
+++ b/app/components/cta.tsx
@@ -4,33 +4,35 @@ export default function CTA({
   link,
   text,
   external,
+  ariaLabel,
 }: {
   link: string
   text: string
   external?: boolean
+  ariaLabel?: string
 }) {
   return (
-    <>
-      <Link
-        href={link}
-        target={external ? '_blank' : undefined}
-        rel={external ? 'noopener noreferrer' : undefined}
-        className="inline-flex items-center gap-2 rounded-full border-[.4px] border-white/40 bg-black p-1.5 pr-3.5 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]"
-      >
-        <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-white pl-[1px]">
-          <svg
-            width="8"
-            height="9"
-            viewBox="0 0 8 9"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path d="M8 4.5L0 9L0 -3.49691e-07L8 4.5Z" fill="#161616" />
-          </svg>
-        </span>
-        <span>{text}</span>
-      </Link>
-    </>
+    <Link
+      href={link}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      aria-label={text ? undefined : ariaLabel}
+      className="inline-flex items-center gap-2 rounded-full border-[0.4px] border-[rgba(246,246,246,0.4)] bg-[#161616] p-1.5 pr-3.5 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]"
+    >
+      <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-white">
+        <svg
+          width="8"
+          height="9"
+          viewBox="0 0 8 9"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          className="ml-[1px]"
+        >
+          <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="#161616" />
+        </svg>
+      </span>
+      {text && <span>{text}</span>}
+    </Link>
   )
 }

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import CTA from './cta'
 
@@ -14,11 +14,30 @@ const links = [
 export default function Nav() {
   const [open, setOpen] = useState(false)
   const pathname = usePathname()
+  const drawerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+      if (e.key !== 'Tab' || !drawerRef.current) return
+      const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled])'
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && active === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     document.addEventListener('keydown', onKey)
     const prevOverflow = document.body.style.overflow
@@ -33,6 +52,9 @@ export default function Nav() {
     setOpen(false)
   }, [pathname])
 
+  const isActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname?.startsWith(href)
+
   return (
     <nav
       aria-label="Primary"
@@ -40,22 +62,30 @@ export default function Nav() {
     >
       <Link
         href="/"
-        className="font-bold tracking-wider text-white text-base md:text-lg"
+        className="font-bold tracking-wider text-white text-base md:text-lg rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
       >
         ADEOLA
       </Link>
 
       {/* Desktop links */}
       <div className="hidden items-center gap-6 md:flex">
-        {links.map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className="text-sm text-white/60 transition-colors duration-200 hover:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795] rounded-sm"
-          >
-            {label}
-          </Link>
-        ))}
+        {links.map(({ href, label }) => {
+          const active = isActive(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              aria-current={active ? 'page' : undefined}
+              className={`nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795] ${
+                active
+                  ? 'nav-link--active border-b border-white pb-0.5'
+                  : ''
+              }`}
+            >
+              {label}
+            </Link>
+          )
+        })}
         <CTA link="mailto:hello@adeola.com" text="Contact" />
       </div>
 
@@ -66,7 +96,7 @@ export default function Nav() {
         aria-expanded={open}
         aria-controls="mobile-nav"
         onClick={() => setOpen((v) => !v)}
-        className="md:hidden flex h-11 w-11 items-center justify-center rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        className="md:hidden relative z-50 flex h-11 w-11 items-center justify-center rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
       >
         <span className="relative block h-4 w-6">
           <span
@@ -90,29 +120,36 @@ export default function Nav() {
       {/* Mobile drawer */}
       <div
         id="mobile-nav"
-        className={`fixed inset-0 z-40 md:hidden ${open ? '' : 'pointer-events-none'}`}
+        className={`fixed inset-0 z-40 md:hidden transition-opacity duration-200 ${
+          open ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
         aria-hidden={!open}
       >
         <div
-          className={`absolute inset-0 bg-[#0e2795]/95 backdrop-blur-sm transition-opacity duration-200 ${
-            open ? 'opacity-100' : 'opacity-0'
-          }`}
+          className="absolute inset-0 bg-[#0e2795] backdrop-blur-sm"
           onClick={() => setOpen(false)}
         />
         <div
-          className={`relative flex h-full flex-col items-start gap-8 p-6 pt-24 transition-transform duration-200 ${
+          ref={drawerRef}
+          className={`relative flex h-full flex-col items-start gap-6 p-6 pt-24 transition-transform duration-200 ${
             open ? 'translate-x-0' : '-translate-x-4'
           }`}
         >
-          {links.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className="text-4xl font-bold uppercase tracking-widest text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-sm"
-            >
-              {label}
-            </Link>
-          ))}
+          {links.map(({ href, label }) => {
+            const active = isActive(href)
+            return (
+              <Link
+                key={href}
+                href={href}
+                aria-current={active ? 'page' : undefined}
+                className={`text-3xl sm:text-4xl font-bold uppercase tracking-widest rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${
+                  active ? 'text-white' : 'text-white/60'
+                }`}
+              >
+                {label}
+              </Link>
+            )
+          })}
           <div className="pt-4">
             <CTA link="mailto:hello@adeola.com" text="Contact" />
           </div>

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link'
+import { sanityFetch } from '@/sanity/lib/live'
+
+type Social = { social: string; url: string }
+
+type General = {
+  socials?: Social[]
+  phone?: string
+  email?: string
+}
+
+const FOOTER_QUERY = `*[_type == "general"][0]{
+  socials[]{ social, url },
+  phone,
+  email
+}`
+
+export default async function SiteFooter({
+  wordmark,
+  size = 'lg',
+}: {
+  wordmark: string
+  size?: 'sm' | 'lg'
+}) {
+  const { data } = await sanityFetch({ query: FOOTER_QUERY })
+  const general = (data ?? {}) as General
+  const socials = general.socials ?? []
+  const hasContact = Boolean(general.phone || general.email)
+
+  const sizeClass =
+    size === 'sm' ? 'display-giant display-giant--sm' : 'display-giant'
+
+  return (
+    <footer className="mt-16 flex flex-col gap-6 md:mt-24">
+      {(socials.length > 0 || hasContact) && (
+        <div className="flex flex-col gap-4 border-t border-white pt-6 pb-2">
+          {socials.length > 0 && (
+            <div className="flex flex-wrap gap-x-8 gap-y-3 px-3">
+              {socials.map((s) => (
+                <Link
+                  key={s.social}
+                  href={s.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="rounded-sm py-1 text-lg md:text-xl font-bold uppercase tracking-widest text-white transition-colors duration-200 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                >
+                  {s.social}
+                </Link>
+              ))}
+            </div>
+          )}
+          {hasContact && (
+            <div className="flex flex-wrap gap-x-8 gap-y-2 px-3">
+              {general.email && (
+                <a
+                  href={`mailto:${general.email}`}
+                  className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                >
+                  {general.email}
+                </a>
+              )}
+              {general.phone && (
+                <a
+                  href={`tel:${general.phone.replace(/\s+/g, '')}`}
+                  className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                >
+                  {general.phone}
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="relative flex w-full flex-col items-center overflow-hidden pt-6 md:pt-10">
+        <span className={`${sizeClass} whitespace-nowrap text-white`}>
+          {wordmark}
+        </span>
+        <span
+          className={`${sizeClass} reflect whitespace-nowrap`}
+          aria-hidden="true"
+        >
+          {wordmark}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-center pb-6">
+        <p className="text-micro">cc. Adeola Ikuesan 2026</p>
+      </div>
+    </footer>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,16 @@
   --color-off-white: #ededed;
   --color-off-white-2: #f6f6f6;
 
+  /* Opacity-scaled white (Tailwind white/N pattern) */
+  --color-white-70: rgba(255, 255, 255, 0.7);
+  --color-white-60: rgba(255, 255, 255, 0.6);
+  --color-white-50: rgba(255, 255, 255, 0.5);
+  --color-white-40: rgba(255, 255, 255, 0.4);
+  --color-white-30: rgba(255, 255, 255, 0.3);
+  --color-white-20: rgba(255, 255, 255, 0.2);
+  --color-white-10: rgba(255, 255, 255, 0.1);
+  --color-white-05: rgba(255, 255, 255, 0.05);
+
   /* Accent gradients */
   --gradient-text-pink-blue: linear-gradient(
     180deg,
@@ -27,22 +37,34 @@
     #f6f6f6 0%,
     rgba(246, 246, 246, 0) 100%
   );
+  --gradient-reflection: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.2) 0%,
+    rgba(255, 255, 255, 0) 70%
+  );
 
   /* Semantic */
   --background: var(--color-brand-blue);
   --foreground: var(--color-white);
+  --foreground-muted: var(--color-white-60);
+  --foreground-dim: var(--color-white-30);
   --button: var(--color-brand-black);
   --border: rgba(246, 246, 246, 0.25);
+  --border-muted: var(--color-white-20);
+  --border-strong: var(--color-white);
+
+  /* Fluid display sizes */
+  --text-display-sm: clamp(4rem, 14vw, 12rem);
+  --text-display-lg: clamp(5rem, 24vw, 22.3125rem);
+  --text-display-xl: clamp(5rem, 14vw, 12.5rem);
 
   /* Layout */
   --container-max: 1440px;
-}
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: var(--color-brand-blue);
-    --foreground: var(--color-off-white);
-  }
+  /* Motion */
+  --transition-fast: 200ms;
+  --transition-medium: 300ms;
+  --easing-default: ease;
 }
 
 body {
@@ -68,7 +90,84 @@ h1 {
   }
 }
 
-/* Gradient text helper used across pages */
+/* ── Semantic typography ──────────────────────────────────── */
+/* VIDEOS / UPCOMING / PAST / AUDIO / ABOUT section labels */
+.display-section {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+@media (min-width: 768px) {
+  .display-section {
+    font-size: 3.75rem;
+  }
+}
+
+/* Giant hero / footer wordmarks — ADE, SHOWS, ADEOLA */
+.display-giant {
+  font-weight: 700;
+  font-size: var(--text-display-lg);
+  letter-spacing: -0.025em;
+  line-height: 0.88;
+  text-transform: uppercase;
+}
+.display-giant--sm {
+  font-size: var(--text-display-sm);
+}
+.display-giant--xl {
+  font-size: var(--text-display-xl);
+}
+
+/* SINGER • SONGWRITER role label */
+.label-role {
+  font-size: 1rem;
+  letter-spacing: -0.025em;
+  color: var(--foreground-muted);
+  text-transform: uppercase;
+}
+
+/* Show row title — fluid 1.875–2rem, widest tracking */
+.show-title {
+  font-size: clamp(1.875rem, 4vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  line-height: 1.1;
+}
+
+/* Body paragraph */
+.body-text {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.025em;
+  line-height: 1.5;
+  color: var(--foreground-muted);
+}
+
+/* Micro / copyright */
+.text-micro {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: var(--foreground);
+}
+
+/* Nav link */
+.nav-link {
+  font-size: 0.875rem;
+  color: var(--foreground-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast) var(--easing-default);
+}
+.nav-link:hover {
+  color: var(--foreground);
+}
+.nav-link--active {
+  color: var(--foreground);
+}
+
+/* ── Gradient text helpers ───────────────────────────────── */
 .text-gradient-pink-blue {
   background-image: var(--gradient-text-pink-blue);
   -webkit-background-clip: text;
@@ -86,4 +185,18 @@ h1 {
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+}
+
+/* ── Signature reflection ────────────────────────────────── */
+/* Apply to a flipped duplicate element underneath display type.
+   Pairs with .display-giant on ADE, SHOWS, ADEOLA wordmarks. */
+.reflect {
+  transform: scaleY(-1);
+  background-image: var(--gradient-reflection);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  pointer-events: none;
+  user-select: none;
+  margin-top: 2px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,19 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor } from '@/sanity/lib/image'
+import { urlFor, hasAsset } from '@/sanity/lib/image'
 import CTA from './components/cta'
+import SiteFooter from './components/site-footer'
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
   title,
   subtitle,
   mainImage,
   profileImage,
-  introShort,
-  socials
+  introShort
 }`
 
-const VIDEO_QUERY = `*[_type == "video"] | order(date desc) [0...4]{
+const VIDEO_QUERY = `*[_type == "video"] | order(date desc) [0...1]{
   _id,
   title,
   subtitle,
@@ -21,13 +21,6 @@ const VIDEO_QUERY = `*[_type == "video"] | order(date desc) [0...4]{
   videourl
 }`
 
-function hasAsset(img: unknown): img is { asset: { _ref: string } } {
-  if (typeof img !== 'object' || img === null) return false
-  const asset = (img as { asset?: unknown }).asset
-  return typeof asset === 'object' && asset !== null && '_ref' in asset
-}
-
-type Social = { social: string; url: string }
 type Video = {
   _id: string
   title: string
@@ -41,15 +34,14 @@ export default async function Home() {
   const { data: videos } = await sanityFetch({ query: VIDEO_QUERY })
 
   const featuredVideo: Video | undefined = videos?.[0]
-  const moreVideos: Video[] = videos?.slice(1) ?? []
 
   return (
-    <div className="flex flex-col gap-6 md:gap-12">
+    <div className="flex flex-col gap-12 md:gap-20">
       {/* ── Hero ── */}
       <section className="relative pt-16 md:pt-24">
-        <div className="grid gap-6 md:grid-cols-2 md:items-center md:gap-10">
+        <div className="grid gap-8 md:grid-cols-2 md:items-center md:gap-10">
           <div className="flex flex-col items-start">
-            <div className="mb-1 flex gap-3 px-1 text-base tracking-tight text-white/60">
+            <div className="label-role mb-2 flex gap-3 px-1">
               <span>SINGER</span>
               <span aria-hidden="true">•</span>
               <span>SONGWRITER</span>
@@ -57,7 +49,7 @@ export default async function Home() {
             <h1 className="font-bold leading-none tracking-tight">
               {general?.title ?? 'ADEOLA'}
             </h1>
-            <div className="mt-4">
+            <div className="mt-5">
               <CTA link="/audio" text="EP OUT NOW" />
             </div>
           </div>
@@ -79,192 +71,103 @@ export default async function Home() {
 
       {/* ── Bio / Quote ── */}
       {general?.introShort && (
-        <section className="relative pb-6">
-          <div className="grid gap-6 md:grid-cols-[1fr_2fr] md:items-center md:gap-10">
-            {hasAsset(general?.profileImage) ? (
-              <div className="relative float-left mr-4 mb-2 aspect-[3/4] w-[40%] md:float-none md:m-0 md:w-full">
+        <section className="relative">
+          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] items-center gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] md:gap-12">
+            {hasAsset(general?.profileImage) && (
+              <div className="relative aspect-[3/4] w-full">
                 <Image
-                  src={urlFor(general.profileImage).width(600).url()}
+                  src={urlFor(general.profileImage).width(700).url()}
                   alt={general.profileImage.alt ?? ''}
                   fill
-                  sizes="(min-width: 768px) 33vw, 40vw"
+                  sizes="(min-width: 768px) 33vw, 35vw"
                   className="object-cover"
                 />
               </div>
-            ) : null}
-            <p className="text-gradient-pink-blue text-2xl font-medium tracking-wide leading-snug md:text-4xl md:leading-tight">
+            )}
+            <p className="text-gradient-pink-blue text-xl font-medium tracking-wide leading-snug sm:text-2xl md:text-4xl md:leading-tight">
               {general.introShort}
             </p>
           </div>
-          <div className="clear-both md:hidden" />
         </section>
       )}
 
-      {/* ── Videos ── */}
-      {videos && videos.length > 0 && (
-        <section className="flex flex-col gap-3 md:gap-6">
-          <div className="flex flex-col gap-1">
-            <p className="text-5xl md:text-6xl font-bold tracking-widest text-white">
-              VIDEOS
-            </p>
-            {featuredVideo?.subtitle && featuredVideo.subtitle.length > 0 && (
-              <p className="text-base tracking-tight text-white/60">
-                {featuredVideo.subtitle.join(' · ')}
-              </p>
-            )}
+      {/* ── Featured video ── */}
+      {featuredVideo && (
+        <section className="flex flex-col gap-4 md:gap-6">
+          <div className="flex items-end justify-between gap-4">
+            <p className="display-section">Video</p>
+            <Link
+              href="/video"
+              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              See all
+            </Link>
           </div>
 
-          {/* Featured video */}
-          {featuredVideo && (
-            <Link
-              href={featuredVideo.videourl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex flex-col gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              <div className="relative aspect-video w-full overflow-hidden bg-white/5">
-                {hasAsset(featuredVideo.thumbnail) ? (
-                  <Image
-                    src={urlFor(featuredVideo.thumbnail).width(1600).url()}
-                    alt={
-                      (featuredVideo.thumbnail as { alt?: string }).alt ??
-                      featuredVideo.title
-                    }
-                    fill
-                    sizes="(min-width: 1024px) 1280px, 100vw"
-                    className="object-cover transition-opacity duration-300 group-hover:opacity-70"
-                  />
-                ) : (
-                  <div className="h-full w-full bg-white/5" />
-                )}
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 md:h-16 md:w-16">
-                    <svg
-                      width="14"
-                      height="16"
-                      viewBox="0 0 8 9"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      aria-hidden="true"
-                    >
-                      <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
-                    </svg>
-                  </div>
+          <Link
+            href={featuredVideo.videourl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            <div className="relative aspect-video w-full overflow-hidden bg-white/5">
+              {hasAsset(featuredVideo.thumbnail) ? (
+                <Image
+                  src={urlFor(featuredVideo.thumbnail).width(1600).url()}
+                  alt={
+                    (featuredVideo.thumbnail as { alt?: string }).alt ??
+                    featuredVideo.title
+                  }
+                  fill
+                  sizes="(min-width: 1024px) 1280px, 100vw"
+                  className="object-cover transition-opacity duration-300 group-hover:opacity-70"
+                />
+              ) : (
+                <div className="h-full w-full bg-white/5" />
+              )}
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 md:h-16 md:w-16">
+                  <svg
+                    width="14"
+                    height="16"
+                    viewBox="0 0 8 9"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
+                  </svg>
                 </div>
               </div>
+            </div>
+            <div className="flex flex-col gap-1">
               <p className="text-xl md:text-2xl font-bold uppercase tracking-tight text-white">
                 {featuredVideo.title}
               </p>
-            </Link>
-          )}
-
-          {/* See all CTA */}
-          <div>
-            <CTA link="/video" text="See all videos" />
-          </div>
-
-          {/* More videos — horizontal scroll on mobile, grid on md+ */}
-          {moreVideos.length > 0 && (
-            <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-2 md:mx-0 md:grid md:grid-cols-3 md:gap-6 md:overflow-visible md:px-0">
-              {moreVideos.map((video) => (
-                <Link
-                  key={video._id}
-                  href={video.videourl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex w-[70vw] max-w-[280px] flex-none flex-col gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 md:w-auto md:max-w-none"
-                >
-                  <div className="relative aspect-video w-full overflow-hidden bg-white/5">
-                    {hasAsset(video.thumbnail) ? (
-                      <Image
-                        src={urlFor(video.thumbnail).width(600).url()}
-                        alt={
-                          (video.thumbnail as { alt?: string }).alt ??
-                          video.title
-                        }
-                        fill
-                        sizes="(min-width: 768px) 33vw, 70vw"
-                        className="object-cover transition-opacity duration-300 group-hover:opacity-70"
-                      />
-                    ) : (
-                      <div className="h-full w-full bg-white/5" />
-                    )}
-                  </div>
-                  <p className="text-sm md:text-base font-bold uppercase tracking-tight text-white">
-                    {video.title}
-                  </p>
-                </Link>
-              ))}
+              {featuredVideo.subtitle && featuredVideo.subtitle.length > 0 && (
+                <p className="text-base tracking-tight text-white/60">
+                  {featuredVideo.subtitle.join(' · ')}
+                </p>
+              )}
             </div>
-          )}
+          </Link>
         </section>
       )}
 
-      {/* ── About ── */}
+      {/* ── About card ── */}
       {general?.introShort && (
-        <section className="flex flex-col gap-6 rounded-xl border border-white p-4 md:p-8">
-          <div className="flex flex-col gap-3">
-            <p className="text-3xl md:text-4xl font-bold uppercase tracking-widest text-white">
-              ABOUT
-            </p>
-            <p className="text-gradient-fade text-base md:text-lg font-medium tracking-wide leading-snug md:leading-relaxed md:max-w-3xl">
-              {general.introShort}
-            </p>
-          </div>
+        <section className="flex flex-col gap-6 rounded-xl border border-white p-6 md:p-10">
+          <p className="display-section">About</p>
+          <p className="text-gradient-fade body-text md:text-lg md:leading-relaxed md:max-w-3xl">
+            {general.introShort}
+          </p>
           <div>
             <CTA link="/about" text="See full bio" />
           </div>
         </section>
       )}
 
-      {/* ── Socials + Footer ── */}
-      <section className="flex flex-col gap-6">
-        {/* Social links */}
-        {general?.socials && general.socials.length > 0 && (
-          <div className="border-t border-white px-3 pt-6 pb-4">
-            <div className="flex flex-wrap gap-x-8 gap-y-3">
-              {general.socials.map((s: Social) => (
-                <Link
-                  key={s.social}
-                  href={s.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="rounded-sm py-1 text-lg md:text-xl font-bold tracking-widest text-white transition-colors duration-200 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                >
-                  {s.social.toUpperCase()}
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Large reflective ADE text */}
-        <div className="relative flex h-48 items-center justify-center overflow-hidden md:h-64">
-          <p
-            className="select-none font-bold leading-none tracking-tighter text-white/10"
-            style={{
-              fontSize: 'clamp(6rem, 28vw, 12rem)',
-              transform: 'scaleY(-1)',
-            }}
-            aria-hidden="true"
-          >
-            ADE
-          </p>
-          <p
-            className="absolute select-none font-bold leading-none tracking-tighter text-white"
-            style={{ fontSize: 'clamp(6rem, 28vw, 12rem)' }}
-          >
-            ADE
-          </p>
-        </div>
-
-        {/* Copyright */}
-        <div className="flex items-center justify-center pb-6">
-          <p className="text-xs tracking-widest text-white">
-            cc. Adeola Ikuesan 2026
-          </p>
-        </div>
-      </section>
+      <SiteFooter wordmark="ADE" size="sm" />
     </div>
   )
 }

--- a/app/shows/page.tsx
+++ b/app/shows/page.tsx
@@ -1,7 +1,8 @@
 import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor } from '@/sanity/lib/image'
+import { urlFor, hasAsset } from '@/sanity/lib/image'
 import CTA from '../components/cta'
+import SiteFooter from '../components/site-footer'
 
 type Ticket = { venue: string; url: string }
 
@@ -12,11 +13,7 @@ type Show = {
   date?: string
   live: boolean
   tickets?: Ticket[]
-}
-
-type Social = {
-  social: string
-  url: string
+  mainImage?: { asset: object; alt?: string }
 }
 
 const SHOWS_QUERY = `*[_type == "show"] | order(date asc){
@@ -25,43 +22,55 @@ const SHOWS_QUERY = `*[_type == "show"] | order(date asc){
   subtitle,
   date,
   live,
-  tickets
+  tickets,
+  mainImage
 }`
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
   mainImage,
-  introShort,
-  socials[]{ social, url }
+  introShort
 }`
 
-function ShowRow({ show, opacity }: { show: Show; opacity?: number }) {
+function formatShowDate(date?: string) {
+  if (!date) return null
+  const d = new Date(date)
+  const day = String(d.getUTCDate()).padStart(2, '0')
+  const month = d
+    .toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+    .toUpperCase()
+  const year = d.getUTCFullYear()
+  const hour = String(d.getUTCHours()).padStart(2, '0')
+  const minute = String(d.getUTCMinutes()).padStart(2, '0')
+  return `${day} ${month} ${year} · ${hour}:${minute}`
+}
+
+function ShowRow({ show, muted }: { show: Show; muted?: boolean }) {
   const location = show.subtitle?.[0]
-  const dateObj = show.date ? new Date(show.date) : null
-  const dateStr = dateObj
-    ? dateObj.toLocaleDateString('en-GB', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-      }) +
-      ' ' +
-      dateObj.toLocaleTimeString('en-GB', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-      })
-    : null
+  const dateStr = formatShowDate(show.date)
 
   return (
     <div
-      className="border-t border-white/20 px-3 py-4 md:py-6"
-      style={opacity !== undefined ? { opacity } : undefined}
+      className={`border-t border-white/20 py-5 md:py-7 ${
+        muted ? 'opacity-50' : ''
+      }`}
     >
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-6">
-        <p className="flex-1 text-2xl font-bold uppercase tracking-widest leading-[1.1] md:text-3xl lg:text-4xl">
-          {show.title}
-        </p>
-        <div className="flex flex-col gap-3 md:flex-1 md:flex-row md:items-center">
-          <div className="flex flex-1 flex-col gap-1">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
+        {hasAsset(show.mainImage) ? (
+          <div className="relative h-20 w-20 shrink-0 md:h-24 md:w-24">
+            <Image
+              src={urlFor(show.mainImage).width(300).url()}
+              alt={show.mainImage.alt ?? ''}
+              fill
+              sizes="96px"
+              className="object-cover"
+            />
+          </div>
+        ) : null}
+
+        <p className="show-title flex-1">{show.title}</p>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:min-w-[18rem] md:justify-end">
+          <div className="flex flex-col gap-1 md:text-right">
             {location && (
               <p className="text-sm tracking-widest text-white/60 md:text-base">
                 {location}
@@ -91,17 +100,16 @@ export default async function ShowsPage() {
   const upcoming: Show[] = shows?.filter((s: Show) => s.live) ?? []
   const past: Show[] = shows?.filter((s: Show) => !s.live) ?? []
   const totalCount = upcoming.length + past.length
-  const socials: Social[] = general?.socials ?? []
 
   return (
-    <div>
+    <div className="flex flex-col">
       {/* Hero */}
-      <div className="pt-24 md:pt-40 lg:pt-48">
-        <div className="flex items-end justify-between w-full gap-4">
+      <section className="pt-20 md:pt-32">
+        <div className="flex items-end justify-between gap-4">
           <div className="flex items-start gap-2 leading-none">
             <span
-              className="font-bold leading-none text-white"
-              style={{ fontSize: 'clamp(80px, 14vw, 200px)' }}
+              className="display-giant display-giant--xl text-white"
+              style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
             >
               SHOWS
             </span>
@@ -123,160 +131,77 @@ export default async function ShowsPage() {
             </svg>
           </div>
         </div>
-        {/* Reflection */}
-        <div
-          className="pointer-events-none select-none"
-          style={{ transform: 'scaleY(-1)' }}
-          aria-hidden="true"
-        >
+        <div className="relative flex flex-col items-start overflow-hidden">
           <span
-            className="block font-bold leading-none"
-            style={{
-              fontSize: 'clamp(80px, 14vw, 200px)',
-              height: 0,
-              backgroundImage:
-                'linear-gradient(to bottom, rgba(255,255,255,0) 13%, rgba(255,255,255,0.01) 81%)',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-              backgroundClip: 'text',
-              textShadow: '0px 51px 5px rgba(255,255,255,0.1)',
-            }}
+            className="display-giant display-giant--xl reflect whitespace-nowrap"
+            aria-hidden="true"
           >
             SHOWS
           </span>
         </div>
-      </div>
-
-      <div className="h-20 md:h-32" />
+      </section>
 
       {/* Intro */}
-      {(general?.mainImage || general?.introShort) && (
-        <div className="mb-16 md:mb-24 w-full">
-          <div className="flex flex-col gap-6 md:flex-row md:items-end md:gap-8">
-            {general?.mainImage && (
+      {(hasAsset(general?.mainImage) || general?.introShort) && (
+        <section className="mt-16 md:mt-24">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:gap-10">
+            {hasAsset(general?.mainImage) && (
               <div className="relative h-60 w-[180px] shrink-0 md:h-[384px] md:w-[329px] lg:h-[520px] lg:w-[420px]">
                 <Image
                   src={urlFor(general.mainImage).width(900).url()}
                   alt={general.mainImage.alt ?? ''}
                   fill
                   sizes="(min-width: 1024px) 420px, (min-width: 768px) 329px, 180px"
-                  className="object-cover"
+                  className="object-cover mix-blend-lighten"
                 />
               </div>
             )}
             {general?.introShort && (
-              <p className="flex-1 text-2xl font-medium leading-tight text-white md:text-4xl lg:text-5xl lg:leading-[0.9]">
+              <p className="flex-1 text-2xl font-medium leading-tight text-white md:text-4xl lg:text-5xl lg:leading-[0.95]">
                 {general.introShort}
               </p>
             )}
           </div>
-        </div>
+        </section>
       )}
 
-      {/* UPCOMING */}
-      <div className="flex w-full flex-col gap-6">
-        <div className="flex items-start gap-2 py-3 leading-none">
-          <span className="text-3xl md:text-5xl font-bold text-white">
-            UPCOMING
-          </span>
-          <span className="text-base md:text-xl font-bold text-white">
+      {/* Upcoming */}
+      <section className="mt-16 md:mt-24 flex w-full flex-col gap-6">
+        <div className="flex items-start gap-2 leading-none">
+          <p className="display-section">Upcoming</p>
+          <span className="text-gradient-gold text-base md:text-xl font-bold">
             ({upcoming.length})
           </span>
         </div>
-        <div className="flex w-full flex-col gap-3">
+        <div className="flex flex-col">
           {upcoming.length > 0 ? (
-            upcoming.map((show: Show) => <ShowRow key={show._id} show={show} />)
+            upcoming.map((show) => <ShowRow key={show._id} show={show} />)
           ) : (
-            <p className="border-t border-white/20 py-5 text-sm text-white/30">
+            <p className="border-t border-white/20 py-5 text-sm text-white/40">
               No upcoming shows at the moment.
             </p>
           )}
         </div>
-      </div>
+      </section>
 
-      <div className="h-16 md:h-24" />
-
-      {/* PAST */}
+      {/* Past */}
       {past.length > 0 && (
-        <div className="flex w-full flex-col gap-6">
-          <div className="flex items-start gap-2 py-3 leading-none">
-            <span className="text-3xl md:text-5xl font-bold uppercase text-white">
-              Past
-            </span>
-            <span className="text-base md:text-xl font-bold text-white">
+        <section className="mt-16 md:mt-24 flex w-full flex-col gap-6">
+          <div className="flex items-start gap-2 leading-none">
+            <p className="display-section">Past</p>
+            <span className="text-base md:text-xl font-bold text-white/60">
               ({past.length})
             </span>
           </div>
-          <div className="flex w-full flex-col gap-3">
-            {past.map((show: Show, index: number) => {
-              const opacityValues = [1, 0.8, 0.6, 0.4]
-              const opacity = opacityValues[index] ?? 0.3
-              return <ShowRow key={show._id} show={show} opacity={opacity} />
-            })}
+          <div className="flex flex-col">
+            {past.map((show) => (
+              <ShowRow key={show._id} show={show} muted />
+            ))}
           </div>
-        </div>
+        </section>
       )}
 
-      <div className="h-16 md:h-24" />
-
-      {/* Footer */}
-      <div className="flex w-full flex-col gap-2.5">
-        {socials.length > 0 && (
-          <div className="flex flex-col gap-3 border-t border-white px-3 pt-6 pb-4">
-            <div className="flex flex-wrap gap-x-6 gap-y-2 text-lg md:text-xl font-bold tracking-widest w-full">
-              {socials.map((s: Social) => (
-                <a
-                  key={s.social}
-                  href={s.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 min-w-[120px] rounded-sm py-1 uppercase text-white transition-colors hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                >
-                  {s.social}
-                </a>
-              ))}
-            </div>
-          </div>
-        )}
-        <div className="flex w-full flex-col items-center justify-end overflow-hidden pt-10 md:pt-16">
-          <span
-            className="font-bold text-white leading-[0.88] whitespace-nowrap"
-            style={{
-              fontSize: 'clamp(60px, 24vw, 357px)',
-              letterSpacing: '-0.02em',
-            }}
-          >
-            ADEOLA
-          </span>
-          <div
-            className="pointer-events-none w-full select-none"
-            style={{ transform: 'scaleY(-1)' }}
-            aria-hidden="true"
-          >
-            <span
-              className="block font-bold"
-              style={{
-                fontSize: 'clamp(60px, 24vw, 357px)',
-                letterSpacing: '-0.02em',
-                height: 0,
-                backgroundImage:
-                  'linear-gradient(180deg, rgba(255,255,255,0) 58.5%, rgba(255,255,255,0.01) 100%)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                backgroundClip: 'text',
-                textShadow: '0px 148px 24px rgba(255,255,255,0.25)',
-              }}
-            >
-              ADEOLA
-            </span>
-          </div>
-        </div>
-        <div className="flex w-full items-center justify-center pt-3">
-          <p className="text-xs tracking-widest text-white">
-            cc. Adeola Ikuesan 2026
-          </p>
-        </div>
-      </div>
+      <SiteFooter wordmark="ADEOLA" />
     </div>
   )
 }

--- a/app/video/page.tsx
+++ b/app/video/page.tsx
@@ -1,7 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor } from '@/sanity/lib/image'
+import { urlFor, hasAsset } from '@/sanity/lib/image'
+import SiteFooter from '../components/site-footer'
 
 type Video = {
   _id: string
@@ -21,81 +22,161 @@ const VIDEO_QUERY = `*[_type == "video"] | order(date desc){
   videourl
 }`
 
+function formatDate(date?: string) {
+  if (!date) return null
+  const d = new Date(date)
+  const day = String(d.getUTCDate()).padStart(2, '0')
+  const month = d
+    .toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+    .toUpperCase()
+  const year = d.getUTCFullYear()
+  return `${day} ${month} ${year}`
+}
+
+function VideoCard({ video, featured }: { video: Video; featured?: boolean }) {
+  return (
+    <Link
+      href={video.videourl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+    >
+      <div className="relative aspect-video w-full overflow-hidden bg-white/5">
+        {hasAsset(video.thumbnail) ? (
+          <Image
+            src={urlFor(video.thumbnail)
+              .width(featured ? 1600 : 900)
+              .url()}
+            alt={(video.thumbnail as { alt?: string }).alt ?? video.title}
+            fill
+            sizes={
+              featured
+                ? '(min-width: 1024px) 1280px, 100vw'
+                : '(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw'
+            }
+            className="object-cover transition-opacity duration-300 group-hover:opacity-70"
+          />
+        ) : (
+          <div className="h-full w-full bg-white/5" />
+        )}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div
+            className={`flex items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 ${
+              featured ? 'h-14 w-14 md:h-16 md:w-16' : 'h-12 w-12 md:h-14 md:w-14'
+            }`}
+          >
+            <svg
+              width="14"
+              height="16"
+              viewBox="0 0 8 9"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p
+          className={`font-bold uppercase tracking-tight text-white ${
+            featured ? 'text-2xl md:text-3xl' : 'text-base md:text-lg'
+          }`}
+        >
+          {video.title}
+        </p>
+        {video.subtitle && video.subtitle.length > 0 && (
+          <p className="text-sm tracking-wide text-white/60 md:text-base">
+            {video.subtitle.join(' · ')}
+          </p>
+        )}
+        {video.date && (
+          <p className="text-micro mt-1 text-white/60">
+            {formatDate(video.date)}
+          </p>
+        )}
+      </div>
+    </Link>
+  )
+}
+
 export default async function VideoPage() {
   const { data: videos } = await sanityFetch({ query: VIDEO_QUERY })
+  const list: Video[] = videos ?? []
+
+  const featured = list[0]
+  const rest = list.slice(1)
+
+  // Group rest by year
+  const groups = new Map<string, Video[]>()
+  for (const v of rest) {
+    const year = v.date ? String(new Date(v.date).getUTCFullYear()) : '—'
+    if (!groups.has(year)) groups.set(year, [])
+    groups.get(year)!.push(v)
+  }
 
   return (
-    <div className="pt-16 md:pt-24">
-      <h1>Video</h1>
+    <div className="flex flex-col">
+      {/* Hero */}
+      <section className="pt-16 md:pt-24">
+        <div className="flex items-start gap-2 leading-none">
+          <p className="display-section">Video</p>
+          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
+            ({list.length})
+          </span>
+        </div>
+        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
+          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
+            VIDEO
+          </span>
+          <span
+            className="display-giant display-giant--xl reflect whitespace-nowrap"
+            aria-hidden="true"
+          >
+            VIDEO
+          </span>
+        </div>
+      </section>
 
-      {videos && videos.length > 0 ? (
-        <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {videos.map((video: Video) => (
-            <Link
-              key={video._id}
-              href={video.videourl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              {/* Thumbnail */}
-              <div className="relative aspect-video w-full overflow-hidden bg-white/5">
-                {video.thumbnail ? (
-                  <Image
-                    src={urlFor(video.thumbnail).width(900).url()}
-                    alt={video.thumbnail.alt ?? video.title}
-                    fill
-                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-                    className="object-cover transition-opacity duration-300 group-hover:opacity-70"
-                  />
-                ) : (
-                  <div className="h-full w-full bg-white/5" />
-                )}
-                {/* Play icon */}
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 md:h-14 md:w-14">
-                    <svg
-                      width="14"
-                      height="16"
-                      viewBox="0 0 8 9"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      aria-hidden="true"
-                    >
-                      <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
-                    </svg>
+      {list.length > 0 ? (
+        <>
+          {featured && (
+            <section className="mt-12 md:mt-20">
+              <VideoCard video={featured} featured />
+            </section>
+          )}
+
+          {rest.length > 0 && (
+            <section className="mt-16 md:mt-24 flex flex-col gap-12 md:gap-16">
+              {Array.from(groups.entries()).map(([year, items]) => (
+                <div key={year} className="flex flex-col gap-6 md:gap-8">
+                  <div className="flex items-baseline gap-3 border-b border-white/20 pb-3">
+                    <p className="text-2xl md:text-3xl font-bold tracking-widest text-white">
+                      {year}
+                    </p>
+                    <span className="text-sm text-white/40 tracking-widest">
+                      ({items.length})
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                    {items.map((video) => (
+                      <VideoCard key={video._id} video={video} />
+                    ))}
                   </div>
                 </div>
-              </div>
-
-              {/* Info */}
-              <div className="flex flex-col gap-1">
-                <p className="text-lg md:text-xl font-medium tracking-tight transition-colors duration-200 group-hover:text-white/70">
-                  {video.title}
-                </p>
-                {video.subtitle && video.subtitle.length > 0 && (
-                  <p className="text-sm md:text-base text-white/60">
-                    {video.subtitle.join(' · ')}
-                  </p>
-                )}
-                {video.date && (
-                  <p className="text-xs md:text-sm text-white/40">
-                    {new Date(video.date).toLocaleDateString('en-US', {
-                      month: 'long',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </p>
-                )}
-              </div>
-            </Link>
-          ))}
-        </div>
+              ))}
+            </section>
+          )}
+        </>
       ) : (
-        <p className="mt-12 border-t border-white/10 pt-5 text-sm text-white/60">
+        <p className="mt-12 border-t border-white/20 pt-5 text-sm text-white/60">
           No videos yet.
         </p>
       )}
+
+      <SiteFooter wordmark="VIDEO" />
     </div>
   )
 }

--- a/sanity/lib/image.ts
+++ b/sanity/lib/image.ts
@@ -9,3 +9,11 @@ const builder = createImageUrlBuilder({ projectId, dataset })
 export const urlFor = (source: SanityImageSource) => {
   return builder.image(source)
 }
+
+export type SanityImage = { asset: { _ref: string }; alt?: string }
+
+export function hasAsset(img: unknown): img is SanityImage {
+  if (typeof img !== 'object' || img === null) return false
+  const asset = (img as { asset?: unknown }).asset
+  return typeof asset === 'object' && asset !== null && '_ref' in asset
+}


### PR DESCRIPTION
Close gaps between design/adeola-ds spec and shipped frontend so every page matches the Shows-page bar. Adds missing tokens, semantic typography classes, and a shared SiteFooter; gives About, Audio, and Video the full hero + reflection treatment; fixes mobile nav drawer (was leaving menu text on top of the page when closed and hiding the close button under the drawer when open).

- globals.css: white opacity scale, reflection gradient, fluid display sizes, motion tokens, and semantic classes (.display-section, .display-giant, .label-role, .show-title, .body-text, .text-micro, .nav-link, .reflect). Drop inert dark-mode block.
- sanity/lib/image.ts: extract shared hasAsset type guard.
- components/site-footer.tsx: new shared footer (socials + phone/email + reflection wordmark + cc. copyright).
- components/nav.tsx: active-state indicator, focus trap in drawer, hamburger raised to z-50 so close affordance stays reachable, drawer fully fades out when closed.
- components/cta.tsx: spec-exact #161616 + ariaLabel fallback.
- Home: label-role hero line, tighter bio grid, featured video only, .reflect .display-giant ADE, SiteFooter.
- About: full hero, ghost-blend portrait, pink-blue blockquotes, SiteFooter.
- Audio: removed max-w-3xl cap, AUDIO hero with gold count, larger cover art, styled native player wrapper, SiteFooter.
- Video: VIDEO hero, featured video, year groupings, corrected hover, DD MMM YYYY dates, SiteFooter.
- Shows: .show-title + .reflect .display-giant, two-tier past-fade, DD MMM YYYY · HH:MM dates, renders show.mainImage when present.