### PR TITLE
feat: collapse to single-page scroll with lenis

### DIFF
--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -2,20 +2,41 @@
 
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
-import { usePathname } from 'next/navigation'
 import CTA from './cta'
 
 const links = [
-  { href: '/shows', label: 'Shows' },
-  { href: '/audio', label: 'Audio' },
-  { href: '/video', label: 'Video' },
+  { id: 'shows', label: 'Shows' },
+  { id: 'audio', label: 'Audio' },
+  { id: 'video', label: 'Video' },
+  { id: 'about', label: 'About' },
 ]
 
 export default function Nav() {
   const [open, setOpen] = useState(false)
-  const pathname = usePathname()
+  const [activeId, setActiveId] = useState<string | null>(null)
   const drawerRef = useRef<HTMLDivElement>(null)
 
+  // Scroll-spy: track which section is most in view
+  useEffect(() => {
+    const sections = links
+      .map(({ id }) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null)
+    if (sections.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)
+        if (visible[0]) setActiveId(visible[0].target.id)
+      },
+      { rootMargin: '-30% 0px -50% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] }
+    )
+    sections.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
+  // Drawer keyboard handling + body scroll lock
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
@@ -48,13 +69,6 @@ export default function Nav() {
     }
   }, [open])
 
-  useEffect(() => {
-    setOpen(false)
-  }, [pathname])
-
-  const isActive = (href: string) =>
-    href === '/' ? pathname === '/' : pathname?.startsWith(href)
-
   return (
     <nav
       aria-label="Primary"
@@ -69,21 +83,19 @@ export default function Nav() {
 
       {/* Desktop links */}
       <div className="hidden items-center gap-6 md:flex">
-        {links.map(({ href, label }) => {
-          const active = isActive(href)
+        {links.map(({ id, label }) => {
+          const active = activeId === id
           return (
-            <Link
-              key={href}
-              href={href}
-              aria-current={active ? 'page' : undefined}
+            <a
+              key={id}
+              href={`/#${id}`}
+              aria-current={active ? 'true' : undefined}
               className={`nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795] ${
-                active
-                  ? 'nav-link--active border-b border-white pb-0.5'
-                  : ''
+                active ? 'nav-link--active border-b border-white pb-0.5' : ''
               }`}
             >
               {label}
-            </Link>
+            </a>
           )
         })}
         <CTA link="mailto:hello@adeola.com" text="Contact" />
@@ -135,19 +147,20 @@ export default function Nav() {
             open ? 'translate-x-0' : '-translate-x-4'
           }`}
         >
-          {links.map(({ href, label }) => {
-            const active = isActive(href)
+          {links.map(({ id, label }) => {
+            const active = activeId === id
             return (
-              <Link
-                key={href}
-                href={href}
-                aria-current={active ? 'page' : undefined}
+              <a
+                key={id}
+                href={`/#${id}`}
+                onClick={() => setOpen(false)}
+                aria-current={active ? 'true' : undefined}
                 className={`text-3xl sm:text-4xl font-bold uppercase tracking-widest rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${
                   active ? 'text-white' : 'text-white/60'
                 }`}
               >
                 {label}
-              </Link>
+              </a>
             )
           })}
           <div className="pt-4">

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image'
 import { PortableText } from '@portabletext/react'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
-import SiteFooter from '../components/site-footer'
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
   title,
@@ -74,70 +73,46 @@ const portableTextComponents = {
   },
 }
 
-export default async function AboutPage() {
+export default async function AboutSection() {
   const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
 
   return (
-    <div className="flex flex-col">
-      {/* Hero */}
-      <section className="pt-16 md:pt-24">
-        <div className="flex items-end justify-between gap-4">
-          <p className="display-section">About</p>
-          <div className="label-role flex gap-3 pb-2 md:pb-4">
-            <span>SINGER</span>
-            <span aria-hidden="true">•</span>
-            <span>SONGWRITER</span>
-          </div>
-        </div>
-        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
-          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
-            ABOUT
-          </span>
-          <span
-            className="display-giant display-giant--xl reflect whitespace-nowrap"
-            aria-hidden="true"
-          >
-            ABOUT
-          </span>
-        </div>
-      </section>
+    <section id="about" className="scroll-mt-24">
+      <div className="flex items-baseline gap-2">
+        <p className="display-section">About</p>
+      </div>
 
-      {/* Content */}
-      <section className="mt-12 md:mt-20">
-        <div className="grid grid-cols-1 items-start gap-10 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] md:gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-20">
-          {hasAsset(general?.mainImage) && (
-            <div className="relative aspect-[3/4] w-full max-w-md md:max-w-none md:sticky md:top-8">
-              <Image
-                src={urlFor(general.mainImage).width(1000).url()}
-                alt={general.mainImage.alt ?? ''}
-                fill
-                sizes="(min-width: 1024px) 40vw, (min-width: 768px) 40vw, 90vw"
-                className="object-cover mix-blend-lighten"
-              />
-            </div>
+      <div className="mt-6 md:mt-8 grid grid-cols-1 items-start gap-10 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] md:gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-20">
+        {hasAsset(general?.mainImage) && (
+          <div className="relative aspect-[3/4] w-full max-w-md md:max-w-none md:sticky md:top-8">
+            <Image
+              src={urlFor(general.mainImage).width(1000).url()}
+              alt={general.mainImage.alt ?? ''}
+              fill
+              sizes="(min-width: 1024px) 40vw, (min-width: 768px) 40vw, 90vw"
+              className="object-cover mix-blend-lighten"
+            />
+          </div>
+        )}
+
+        <div>
+          {general?.title && (
+            <p className="label-role mb-6">{general.title}</p>
           )}
-
-          <div>
-            {general?.title && (
-              <p className="label-role mb-6">{general.title}</p>
-            )}
-            {general?.introLong ? (
-              <PortableText
-                value={general.introLong}
-                components={portableTextComponents}
-              />
-            ) : general?.introShort ? (
-              <p className="body-text text-white/80 md:text-lg md:leading-relaxed">
-                {general.introShort}
-              </p>
-            ) : (
-              <p className="text-sm text-white/60">No bio yet.</p>
-            )}
-          </div>
+          {general?.introLong ? (
+            <PortableText
+              value={general.introLong}
+              components={portableTextComponents}
+            />
+          ) : general?.introShort ? (
+            <p className="body-text text-white/80 md:text-lg md:leading-relaxed">
+              {general.introShort}
+            </p>
+          ) : (
+            <p className="text-sm text-white/60">No bio yet.</p>
+          )}
         </div>
-      </section>
-
-      <SiteFooter wordmark="ADEOLA" />
-    </div>
+      </div>
+    </section>
   )
 }

--- a/app/components/sections/audio-section.tsx
+++ b/app/components/sections/audio-section.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
-import SiteFooter from '../components/site-footer'
 
 type Track = {
   _id: string
@@ -19,35 +18,20 @@ const AUDIO_QUERY = `*[_type == "audio"] | order(_createdAt desc){
   coverImage
 }`
 
-export default async function AudioPage() {
+export default async function AudioSection() {
   const { data: tracks } = await sanityFetch({ query: AUDIO_QUERY })
   const trackList: Track[] = tracks ?? []
 
   return (
-    <div className="flex flex-col">
-      {/* Hero */}
-      <section className="pt-16 md:pt-24">
-        <div className="flex items-start gap-2 leading-none">
-          <p className="display-section">Audio</p>
-          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
-            ({trackList.length})
-          </span>
-        </div>
-        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
-          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
-            AUDIO
-          </span>
-          <span
-            className="display-giant display-giant--xl reflect whitespace-nowrap"
-            aria-hidden="true"
-          >
-            AUDIO
-          </span>
-        </div>
-      </section>
+    <section id="audio" className="scroll-mt-24">
+      <div className="flex items-baseline gap-2">
+        <p className="display-section">Audio</p>
+        <span className="text-gradient-gold text-sm md:text-base font-bold">
+          ({trackList.length})
+        </span>
+      </div>
 
-      {/* Tracks */}
-      <section className="mt-12 md:mt-20">
+      <div className="mt-6 md:mt-8">
         {trackList.length > 0 ? (
           <div className="flex flex-col">
             {trackList.map((track) => (
@@ -70,11 +54,9 @@ export default async function AudioPage() {
                     <div className="h-20 w-20 shrink-0 bg-white/5 md:h-24 md:w-24 lg:h-28 lg:w-28" />
                   )}
                   <div className="flex flex-col gap-1">
-                    <p className="text-lg md:text-xl font-bold uppercase tracking-widest text-white">
-                      {track.title}
-                    </p>
+                    <p className="show-title text-white">{track.title}</p>
                     {track.subtitle && (
-                      <p className="text-sm tracking-wide text-white/60 md:text-base">
+                      <p className="text-sm tracking-wide text-white/60">
                         {track.subtitle}
                       </p>
                     )}
@@ -83,7 +65,7 @@ export default async function AudioPage() {
 
                 <div className="md:flex-1 md:max-w-md">
                   {track.audio?.asset?.url ? (
-                    <div className="bg-white/5 p-2 rounded-full">
+                    <div className="rounded-full bg-white/5 p-2">
                       <audio
                         controls
                         src={track.audio.asset.url}
@@ -105,9 +87,7 @@ export default async function AudioPage() {
             No tracks yet.
           </p>
         )}
-      </section>
-
-      <SiteFooter wordmark="AUDIO" />
-    </div>
+      </div>
+    </section>
   )
 }

--- a/app/components/sections/shows-section.tsx
+++ b/app/components/sections/shows-section.tsx
@@ -1,8 +1,7 @@
 import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
-import CTA from '../components/cta'
-import SiteFooter from '../components/site-footer'
+import CTA from '../cta'
 
 type Ticket = { venue: string; url: string }
 
@@ -56,30 +55,26 @@ function ShowRow({ show, muted }: { show: Show; muted?: boolean }) {
     >
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
         {hasAsset(show.mainImage) ? (
-          <div className="relative h-20 w-20 shrink-0 md:h-24 md:w-24">
+          <div className="relative h-16 w-16 shrink-0 md:h-20 md:w-20">
             <Image
-              src={urlFor(show.mainImage).width(300).url()}
+              src={urlFor(show.mainImage).width(240).url()}
               alt={show.mainImage.alt ?? ''}
               fill
-              sizes="96px"
+              sizes="80px"
               className="object-cover"
             />
           </div>
         ) : null}
 
-        <p className="show-title flex-1">{show.title}</p>
+        <p className="show-title flex-1 text-white">{show.title}</p>
 
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:min-w-[18rem] md:justify-end">
           <div className="flex flex-col gap-1 md:text-right">
             {location && (
-              <p className="text-sm tracking-widest text-white/60 md:text-base">
-                {location}
-              </p>
+              <p className="text-sm tracking-widest text-white/60">{location}</p>
             )}
             {dateStr && (
-              <p className="text-sm tracking-widest text-white/60 md:text-base">
-                {dateStr}
-              </p>
+              <p className="text-sm tracking-widest text-white/60">{dateStr}</p>
             )}
           </div>
           {show.live && show.tickets && show.tickets[0] && (
@@ -93,7 +88,7 @@ function ShowRow({ show, muted }: { show: Show; muted?: boolean }) {
   )
 }
 
-export default async function ShowsPage() {
+export default async function ShowsSection() {
   const { data: shows } = await sanityFetch({ query: SHOWS_QUERY })
   const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
 
@@ -102,48 +97,34 @@ export default async function ShowsPage() {
   const totalCount = upcoming.length + past.length
 
   return (
-    <div className="flex flex-col">
-      {/* Hero */}
-      <section className="pt-20 md:pt-32">
-        <div className="flex items-end justify-between gap-4">
-          <div className="flex items-start gap-2 leading-none">
-            <span
-              className="display-giant display-giant--xl text-white"
-              style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
-            >
-              SHOWS
-            </span>
-            <span className="text-gradient-gold text-lg md:text-2xl font-bold">
-              ({totalCount})
-            </span>
-          </div>
-          <div className="flex items-center gap-2 pb-2 md:pb-5 text-white">
-            <span className="text-base md:text-2xl font-medium">Explore</span>
-            <svg
-              width="11"
-              height="13"
-              viewBox="0 0 13 11"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path d="M13 5.5L0 11L0 0L13 5.5Z" fill="white" />
-            </svg>
-          </div>
-        </div>
-        <div className="relative flex flex-col items-start overflow-hidden">
+    <section id="shows" className="scroll-mt-24">
+      {/* Signature SHOWS giant — the one display-giant moment kept */}
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex items-start gap-2 leading-none">
           <span
-            className="display-giant display-giant--xl reflect whitespace-nowrap"
-            aria-hidden="true"
+            className="display-giant display-giant--xl text-white"
+            style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
           >
             SHOWS
           </span>
+          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
+            ({totalCount})
+          </span>
         </div>
-      </section>
+      </div>
+      <div className="relative flex flex-col items-start overflow-hidden">
+        <span
+          className="display-giant display-giant--xl reflect whitespace-nowrap"
+          aria-hidden="true"
+          style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
+        >
+          SHOWS
+        </span>
+      </div>
 
       {/* Intro */}
       {(hasAsset(general?.mainImage) || general?.introShort) && (
-        <section className="mt-16 md:mt-24">
+        <div className="mt-12 md:mt-16">
           <div className="flex flex-col gap-6 md:flex-row md:items-end md:gap-10">
             {hasAsset(general?.mainImage) && (
               <div className="relative h-60 w-[180px] shrink-0 md:h-[384px] md:w-[329px] lg:h-[520px] lg:w-[420px]">
@@ -162,14 +143,14 @@ export default async function ShowsPage() {
               </p>
             )}
           </div>
-        </section>
+        </div>
       )}
 
       {/* Upcoming */}
-      <section className="mt-16 md:mt-24 flex w-full flex-col gap-6">
-        <div className="flex items-start gap-2 leading-none">
+      <div className="mt-12 md:mt-16 flex w-full flex-col gap-6">
+        <div className="flex items-baseline gap-2">
           <p className="display-section">Upcoming</p>
-          <span className="text-gradient-gold text-base md:text-xl font-bold">
+          <span className="text-gradient-gold text-sm md:text-base font-bold">
             ({upcoming.length})
           </span>
         </div>
@@ -182,14 +163,14 @@ export default async function ShowsPage() {
             </p>
           )}
         </div>
-      </section>
+      </div>
 
       {/* Past */}
       {past.length > 0 && (
-        <section className="mt-16 md:mt-24 flex w-full flex-col gap-6">
-          <div className="flex items-start gap-2 leading-none">
+        <div className="mt-12 md:mt-16 flex w-full flex-col gap-6">
+          <div className="flex items-baseline gap-2">
             <p className="display-section">Past</p>
-            <span className="text-base md:text-xl font-bold text-white/60">
+            <span className="text-sm md:text-base font-bold text-white/60">
               ({past.length})
             </span>
           </div>
@@ -198,10 +179,8 @@ export default async function ShowsPage() {
               <ShowRow key={show._id} show={show} muted />
             ))}
           </div>
-        </section>
+        </div>
       )}
-
-      <SiteFooter wordmark="ADEOLA" />
-    </div>
+    </section>
   )
 }

--- a/app/components/sections/video-section.tsx
+++ b/app/components/sections/video-section.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
-import SiteFooter from '../components/site-footer'
 
 type Video = {
   _id: string
@@ -80,15 +79,9 @@ function VideoCard({ video, featured }: { video: Video; featured?: boolean }) {
       </div>
 
       <div className="flex flex-col gap-1">
-        <p
-          className={`font-bold uppercase tracking-tight text-white ${
-            featured ? 'text-2xl md:text-3xl' : 'text-base md:text-lg'
-          }`}
-        >
-          {video.title}
-        </p>
+        <p className="show-title text-white">{video.title}</p>
         {video.subtitle && video.subtitle.length > 0 && (
-          <p className="text-sm tracking-wide text-white/60 md:text-base">
+          <p className="text-sm tracking-wide text-white/60">
             {video.subtitle.join(' · ')}
           </p>
         )}
@@ -102,14 +95,13 @@ function VideoCard({ video, featured }: { video: Video; featured?: boolean }) {
   )
 }
 
-export default async function VideoPage() {
+export default async function VideoSection() {
   const { data: videos } = await sanityFetch({ query: VIDEO_QUERY })
   const list: Video[] = videos ?? []
 
   const featured = list[0]
   const rest = list.slice(1)
 
-  // Group rest by year
   const groups = new Map<string, Video[]>()
   for (const v of rest) {
     const year = v.date ? String(new Date(v.date).getUTCFullYear()) : '—'
@@ -118,42 +110,24 @@ export default async function VideoPage() {
   }
 
   return (
-    <div className="flex flex-col">
-      {/* Hero */}
-      <section className="pt-16 md:pt-24">
-        <div className="flex items-start gap-2 leading-none">
-          <p className="display-section">Video</p>
-          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
-            ({list.length})
-          </span>
-        </div>
-        <div className="relative mt-6 flex flex-col items-center overflow-hidden">
-          <span className="display-giant display-giant--xl whitespace-nowrap text-white">
-            VIDEO
-          </span>
-          <span
-            className="display-giant display-giant--xl reflect whitespace-nowrap"
-            aria-hidden="true"
-          >
-            VIDEO
-          </span>
-        </div>
-      </section>
+    <section id="video" className="scroll-mt-24">
+      <div className="flex items-baseline gap-2">
+        <p className="display-section">Video</p>
+        <span className="text-gradient-gold text-sm md:text-base font-bold">
+          ({list.length})
+        </span>
+      </div>
 
       {list.length > 0 ? (
-        <>
-          {featured && (
-            <section className="mt-12 md:mt-20">
-              <VideoCard video={featured} featured />
-            </section>
-          )}
+        <div className="mt-6 md:mt-8 flex flex-col gap-12 md:gap-16">
+          {featured && <VideoCard video={featured} featured />}
 
           {rest.length > 0 && (
-            <section className="mt-16 md:mt-24 flex flex-col gap-12 md:gap-16">
+            <div className="flex flex-col gap-12 md:gap-16">
               {Array.from(groups.entries()).map(([year, items]) => (
                 <div key={year} className="flex flex-col gap-6 md:gap-8">
                   <div className="flex items-baseline gap-3 border-b border-white/20 pb-3">
-                    <p className="text-2xl md:text-3xl font-bold tracking-widest text-white">
+                    <p className="text-base font-bold tracking-widest text-white">
                       {year}
                     </p>
                     <span className="text-sm text-white/40 tracking-widest">
@@ -167,16 +141,14 @@ export default async function VideoPage() {
                   </div>
                 </div>
               ))}
-            </section>
+            </div>
           )}
-        </>
+        </div>
       ) : (
-        <p className="mt-12 border-t border-white/20 pt-5 text-sm text-white/60">
+        <p className="mt-6 border-t border-white/20 pt-5 text-sm text-white/60">
           No videos yet.
         </p>
       )}
-
-      <SiteFooter wordmark="VIDEO" />
-    </div>
+    </section>
   )
 }

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -15,76 +15,50 @@ const FOOTER_QUERY = `*[_type == "general"][0]{
   email
 }`
 
-export default async function SiteFooter({
-  wordmark,
-  size = 'lg',
-}: {
-  wordmark: string
-  size?: 'sm' | 'lg'
-}) {
+export default async function SiteFooter() {
   const { data } = await sanityFetch({ query: FOOTER_QUERY })
   const general = (data ?? {}) as General
   const socials = general.socials ?? []
   const hasContact = Boolean(general.phone || general.email)
 
-  const sizeClass =
-    size === 'sm' ? 'display-giant display-giant--sm' : 'display-giant'
-
   return (
-    <footer className="mt-16 flex flex-col gap-6 md:mt-24">
-      {(socials.length > 0 || hasContact) && (
-        <div className="flex flex-col gap-4 border-t border-white pt-6 pb-2">
-          {socials.length > 0 && (
-            <div className="flex flex-wrap gap-x-8 gap-y-3 px-3">
-              {socials.map((s) => (
-                <Link
-                  key={s.social}
-                  href={s.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="rounded-sm py-1 text-lg md:text-xl font-bold uppercase tracking-widest text-white transition-colors duration-200 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                >
-                  {s.social}
-                </Link>
-              ))}
-            </div>
+    <footer className="flex flex-col gap-4 border-t border-white pt-6 pb-8">
+      {socials.length > 0 && (
+        <div className="flex flex-wrap gap-x-8 gap-y-3 px-3">
+          {socials.map((s) => (
+            <Link
+              key={s.social}
+              href={s.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-sm py-1 text-sm md:text-base font-bold uppercase tracking-widest text-white transition-colors duration-200 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              {s.social}
+            </Link>
+          ))}
+        </div>
+      )}
+      {hasContact && (
+        <div className="flex flex-wrap gap-x-8 gap-y-2 px-3">
+          {general.email && (
+            <a
+              href={`mailto:${general.email}`}
+              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              {general.email}
+            </a>
           )}
-          {hasContact && (
-            <div className="flex flex-wrap gap-x-8 gap-y-2 px-3">
-              {general.email && (
-                <a
-                  href={`mailto:${general.email}`}
-                  className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                >
-                  {general.email}
-                </a>
-              )}
-              {general.phone && (
-                <a
-                  href={`tel:${general.phone.replace(/\s+/g, '')}`}
-                  className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                >
-                  {general.phone}
-                </a>
-              )}
-            </div>
+          {general.phone && (
+            <a
+              href={`tel:${general.phone.replace(/\s+/g, '')}`}
+              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              {general.phone}
+            </a>
           )}
         </div>
       )}
-
-      <div className="relative flex w-full flex-col items-center overflow-hidden pt-6 md:pt-10">
-        <span className={`${sizeClass} whitespace-nowrap text-white`}>
-          {wordmark}
-        </span>
-        <span
-          className={`${sizeClass} reflect whitespace-nowrap`}
-          aria-hidden="true"
-        >
-          {wordmark}
-        </span>
-      </div>
-
-      <div className="flex items-center justify-center pb-6">
+      <div className="px-3 pt-2">
         <p className="text-micro">cc. Adeola Ikuesan 2026</p>
       </div>
     </footer>

--- a/app/components/smooth-scroll.tsx
+++ b/app/components/smooth-scroll.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect } from 'react'
+import Lenis from 'lenis'
+
+export default function SmoothScroll() {
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return
+    }
+
+    const lenis = new Lenis({ lerp: 0.1 })
+    let frame = 0
+    const raf = (time: number) => {
+      lenis.raf(time)
+      frame = requestAnimationFrame(raf)
+    }
+    frame = requestAnimationFrame(raf)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      lenis.destroy()
+    }
+  }, [])
+
+  return null
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'lenis/dist/lenis.css';
 
 /* Adeola Design System — tokens sourced from design/adeola-ds/colors_and_type.css */
 :root {
@@ -93,7 +94,7 @@ h1 {
 /* ── Semantic typography ──────────────────────────────────── */
 /* VIDEOS / UPCOMING / PAST / AUDIO / ABOUT section labels */
 .display-section {
-  font-size: 3rem;
+  font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -101,7 +102,7 @@ h1 {
 }
 @media (min-width: 768px) {
   .display-section {
-    font-size: 3.75rem;
+    font-size: 1.5rem;
   }
 }
 
@@ -128,13 +129,13 @@ h1 {
   text-transform: uppercase;
 }
 
-/* Show row title — fluid 1.875–2rem, widest tracking */
+/* Show row title — tightened to read as a uniform list */
 .show-title {
-  font-size: clamp(1.875rem, 4vw, 2.25rem);
+  font-size: 1.125rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  line-height: 1.1;
+  line-height: 1.2;
 }
 
 /* Body paragraph */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import Container from './components/container'
 import Nav from './components/nav'
+import SmoothScroll from './components/smooth-scroll'
 import { SanityLive } from '@/sanity/lib/live'
 
 export const metadata: Metadata = {
@@ -23,6 +24,7 @@ export default function RootLayout({
         >
           Skip to content
         </a>
+        <SmoothScroll />
         <Container>
           <Nav />
           <main id="main-content">{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 import Image from 'next/image'
-import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
 import CTA from './components/cta'
 import SiteFooter from './components/site-footer'
+import ShowsSection from './components/sections/shows-section'
+import AudioSection from './components/sections/audio-section'
+import VideoSection from './components/sections/video-section'
+import AboutSection from './components/sections/about-section'
 
-const GENERAL_QUERY = `*[_type == "general"][0]{
+const HERO_QUERY = `*[_type == "general"][0]{
   title,
   subtitle,
   mainImage,
@@ -13,31 +16,12 @@ const GENERAL_QUERY = `*[_type == "general"][0]{
   introShort
 }`
 
-const VIDEO_QUERY = `*[_type == "video"] | order(date desc) [0...1]{
-  _id,
-  title,
-  subtitle,
-  thumbnail,
-  videourl
-}`
-
-type Video = {
-  _id: string
-  title: string
-  subtitle?: string[]
-  thumbnail?: { asset: object; alt?: string }
-  videourl: string
-}
-
 export default async function Home() {
-  const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
-  const { data: videos } = await sanityFetch({ query: VIDEO_QUERY })
-
-  const featuredVideo: Video | undefined = videos?.[0]
+  const { data: general } = await sanityFetch({ query: HERO_QUERY })
 
   return (
-    <div className="flex flex-col gap-12 md:gap-20">
-      {/* ── Hero ── */}
+    <div className="flex flex-col gap-20 md:gap-32">
+      {/* Hero */}
       <section className="relative pt-16 md:pt-24">
         <div className="grid gap-8 md:grid-cols-2 md:items-center md:gap-10">
           <div className="flex flex-col items-start">
@@ -50,7 +34,7 @@ export default async function Home() {
               {general?.title ?? 'ADEOLA'}
             </h1>
             <div className="mt-5">
-              <CTA link="/audio" text="EP OUT NOW" />
+              <CTA link="#audio" text="EP OUT NOW" />
             </div>
           </div>
 
@@ -69,10 +53,10 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* ── Bio / Quote ── */}
+      {/* Bio quote */}
       {general?.introShort && (
-        <section className="relative">
-          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] items-center gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] md:gap-12">
+        <section>
+          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] items-center gap-5 md:gap-12">
             {hasAsset(general?.profileImage) && (
               <div className="relative aspect-[3/4] w-full">
                 <Image
@@ -91,83 +75,12 @@ export default async function Home() {
         </section>
       )}
 
-      {/* ── Featured video ── */}
-      {featuredVideo && (
-        <section className="flex flex-col gap-4 md:gap-6">
-          <div className="flex items-end justify-between gap-4">
-            <p className="display-section">Video</p>
-            <Link
-              href="/video"
-              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              See all
-            </Link>
-          </div>
+      <ShowsSection />
+      <AudioSection />
+      <VideoSection />
+      <AboutSection />
 
-          <Link
-            href={featuredVideo.videourl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group flex flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-          >
-            <div className="relative aspect-video w-full overflow-hidden bg-white/5">
-              {hasAsset(featuredVideo.thumbnail) ? (
-                <Image
-                  src={urlFor(featuredVideo.thumbnail).width(1600).url()}
-                  alt={
-                    (featuredVideo.thumbnail as { alt?: string }).alt ??
-                    featuredVideo.title
-                  }
-                  fill
-                  sizes="(min-width: 1024px) 1280px, 100vw"
-                  className="object-cover transition-opacity duration-300 group-hover:opacity-70"
-                />
-              ) : (
-                <div className="h-full w-full bg-white/5" />
-              )}
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 md:h-16 md:w-16">
-                  <svg
-                    width="14"
-                    height="16"
-                    viewBox="0 0 8 9"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                  >
-                    <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-            <div className="flex flex-col gap-1">
-              <p className="text-xl md:text-2xl font-bold uppercase tracking-tight text-white">
-                {featuredVideo.title}
-              </p>
-              {featuredVideo.subtitle && featuredVideo.subtitle.length > 0 && (
-                <p className="text-base tracking-tight text-white/60">
-                  {featuredVideo.subtitle.join(' · ')}
-                </p>
-              )}
-            </div>
-          </Link>
-        </section>
-      )}
-
-      {/* ── About card ── */}
-      {general?.introShort && (
-        <section className="flex flex-col gap-6 rounded-xl border border-white p-6 md:p-10">
-          <p className="display-section">About</p>
-          <p className="text-gradient-fade body-text md:text-lg md:leading-relaxed md:max-w-3xl">
-            {general.introShort}
-          </p>
-          <div>
-            <CTA link="/about" text="See full bio" />
-          </div>
-        </section>
-      )}
-
-      <SiteFooter wordmark="ADE" size="sm" />
+      <SiteFooter />
     </div>
   )
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      { source: '/shows', destination: '/#shows', permanent: true },
+      { source: '/audio', destination: '/#audio', permanent: true },
+      { source: '/video', destination: '/#video', permanent: true },
+      { source: '/about', destination: '/#about', permanent: true },
+    ]
+  },
 }
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@portabletext/react": "^6.0.3",
         "@sanity/image-url": "^1.1.0",
         "@sanity/vision": "^3.77.2",
+        "lenis": "^1.3.23",
         "next": "^15.5.12",
         "next-sanity": "^9.8.60",
         "react": "19.2.4",
@@ -12617,6 +12618,36 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/lenis": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz",
+      "integrity": "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12676,6 +12707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12696,6 +12728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12716,6 +12749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12736,6 +12770,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12756,6 +12791,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12776,6 +12812,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12796,6 +12833,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12816,6 +12854,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12836,6 +12875,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12856,6 +12896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@portabletext/react": "^6.0.3",
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.77.2",
+    "lenis": "^1.3.23",
     "next": "^15.5.12",
     "next-sanity": "^9.8.60",
     "react": "19.2.4",


### PR DESCRIPTION
One long page of anchor sections, tighter near-uniform typography, and Lenis smooth scroll. Cobalt + DS foundation unchanged.

- Single-page restructure: /shows, /audio, /video, /about content lifted into app/components/sections/*-section.tsx and composed on app/page.tsx. The four route files deleted; next.config.ts issues 308 redirects to /#<section> so inbound links still resolve.
- Nav becomes anchor jump-links, active state driven by IntersectionObserver scroll-spy, mobile drawer auto-closes on click.
- Typography tightened: .display-section 3rem → 1.25rem (1.5rem md), .show-title fluid → fixed 1.125rem. Only SHOWS keeps its display-giant reflection as the single signature moment; ADE, ADEOLA, AUDIO, VIDEO footer wordmarks removed.
- SiteFooter stripped to socials + phone/email + cc. copyright.
- SmoothScroll client component mounts Lenis in layout.tsx, short- circuits on prefers-reduced-motion. lenis/dist/lenis.css imported.