### PR TITLE
feat: land portfolio redesign from design handoff

### DIFF
--- a/app/components/contact-modal.tsx
+++ b/app/components/contact-modal.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import CTA from './cta'
+
+export default function ContactModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: () => void
+}) {
+  const [sent, setSent] = useState(false)
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  function handleClose() {
+    onClose()
+    setTimeout(() => {
+      setSent(false)
+      setName('')
+      setEmail('')
+      setMessage('')
+    }, 300)
+  }
+
+  if (!open) return null
+
+  const fieldStyle: React.CSSProperties = {
+    border: 'none',
+    borderBottom: '0.5px solid rgba(255,255,255,0.35)',
+    letterSpacing: '0.01em',
+    fontFamily: 'inherit',
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Contact form"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose()
+      }}
+      className="fixed inset-0 z-[9000] flex items-center justify-center p-6"
+      style={{ background: 'rgba(4,12,40,0.72)', backdropFilter: 'blur(10px)' }}
+    >
+      <div
+        className="relative flex w-full max-w-[480px] flex-col gap-7"
+        style={{
+          background: '#0e2795',
+          border: '1px solid rgba(255,255,255,0.25)',
+          borderRadius: 16,
+          padding: 'clamp(28px, 5vw, 48px)',
+        }}
+      >
+        <button
+          onClick={handleClose}
+          aria-label="Close"
+          className="absolute right-[18px] top-[18px] cursor-pointer bg-transparent p-1 text-base leading-none text-white/50 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          style={{ border: 'none' }}
+        >
+          ✕
+        </button>
+
+        <p style={{ fontSize: '1.4rem', fontWeight: 700, letterSpacing: '0.06em' }}>
+          GET IN TOUCH
+        </p>
+
+        {sent ? (
+          <p
+            style={{
+              color: 'rgba(255,255,255,0.75)',
+              fontSize: '1rem',
+              lineHeight: 1.6,
+              paddingBottom: 12,
+            }}
+          >
+            Thanks — I&apos;ll get back to you.
+          </p>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              setSent(true)
+            }}
+            className="flex flex-col gap-5"
+          >
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="contact-name"
+                style={{
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.22em',
+                  color: 'rgba(255,255,255,0.55)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Name
+              </label>
+              <input
+                id="contact-name"
+                type="text"
+                required
+                placeholder="Your name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="bg-transparent py-2.5 text-base text-white outline-none placeholder:text-white/30"
+                style={fieldStyle}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="contact-email"
+                style={{
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.22em',
+                  color: 'rgba(255,255,255,0.55)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Email
+              </label>
+              <input
+                id="contact-email"
+                type="email"
+                required
+                placeholder="your@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="bg-transparent py-2.5 text-base text-white outline-none placeholder:text-white/30"
+                style={fieldStyle}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="contact-message"
+                style={{
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.22em',
+                  color: 'rgba(255,255,255,0.55)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Message
+              </label>
+              <textarea
+                id="contact-message"
+                required
+                rows={4}
+                placeholder="What&apos;s on your mind?"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                className="resize-none bg-transparent py-2.5 text-base text-white outline-none placeholder:text-white/30"
+                style={fieldStyle}
+              />
+            </div>
+            <div className="pt-1">
+              <CTA type="submit" text="Send message" />
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/components/container.tsx
+++ b/app/components/container.tsx
@@ -1,5 +1,5 @@
 export default function Container({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mx-auto w-full max-w-[1440px] p-4 md:p-8">{children}</div>
+    <div className="mx-auto w-full max-w-[1040px] px-5 md:px-10">{children}</div>
   )
 }

--- a/app/components/cta.tsx
+++ b/app/components/cta.tsx
@@ -1,38 +1,65 @@
 import Link from 'next/link'
 
+const pillClass =
+  'inline-flex items-center gap-2 rounded-full border-[0.4px] border-[rgba(246,246,246,0.4)] bg-[#161616] p-1.5 pr-3.5 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]'
+
+function IconCircle() {
+  return (
+    <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-white">
+      <svg
+        width="8"
+        height="9"
+        viewBox="0 0 8 9"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        className="ml-[1px]"
+      >
+        <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="#161616" />
+      </svg>
+    </span>
+  )
+}
+
 export default function CTA({
   link,
   text,
   external,
   ariaLabel,
+  onClick,
+  type = 'button',
 }: {
-  link: string
+  link?: string
   text: string
   external?: boolean
   ariaLabel?: string
+  onClick?: () => void
+  type?: 'button' | 'submit'
 }) {
+  if (link) {
+    return (
+      <Link
+        href={link}
+        target={external ? '_blank' : undefined}
+        rel={external ? 'noopener noreferrer' : undefined}
+        aria-label={text ? undefined : ariaLabel}
+        className={pillClass}
+      >
+        <IconCircle />
+        {text && <span>{text}</span>}
+      </Link>
+    )
+  }
+
   return (
-    <Link
-      href={link}
-      target={external ? '_blank' : undefined}
-      rel={external ? 'noopener noreferrer' : undefined}
+    <button
+      type={type}
+      onClick={onClick}
       aria-label={text ? undefined : ariaLabel}
-      className="inline-flex items-center gap-2 rounded-full border-[0.4px] border-[rgba(246,246,246,0.4)] bg-[#161616] p-1.5 pr-3.5 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]"
+      className={pillClass}
     >
-      <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-white">
-        <svg
-          width="8"
-          height="9"
-          viewBox="0 0 8 9"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-          className="ml-[1px]"
-        >
-          <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="#161616" />
-        </svg>
-      </span>
+      <IconCircle />
       {text && <span>{text}</span>}
-    </Link>
+    </button>
   )
 }

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -1,22 +1,23 @@
 'use client'
 
-import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import CTA from './cta'
+import ContactModal from './contact-modal'
 
 const links = [
+  { id: 'music', label: 'Music' },
   { id: 'shows', label: 'Shows' },
-  { id: 'audio', label: 'Audio' },
-  { id: 'video', label: 'Video' },
+  { id: 'video', label: 'Videos' },
   { id: 'about', label: 'About' },
+  { id: 'newsletter', label: 'Newsletter' },
 ]
 
 export default function Nav() {
   const [open, setOpen] = useState(false)
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [contactOpen, setContactOpen] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
 
-  // Scroll-spy: track which section is most in view
   useEffect(() => {
     const sections = links
       .map(({ id }) => document.getElementById(id))
@@ -36,7 +37,6 @@ export default function Nav() {
     return () => observer.disconnect()
   }, [])
 
-  // Drawer keyboard handling + body scroll lock
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
@@ -70,69 +70,66 @@ export default function Nav() {
   }, [open])
 
   return (
-    <nav
-      aria-label="Primary"
-      className="flex w-full items-center justify-between"
-    >
-      <Link
-        href="/"
-        className="font-bold tracking-wider text-white text-base md:text-lg rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+    <>
+      <nav
+        aria-label="Primary"
+        className="flex w-full items-center justify-between py-[22px]"
       >
-        ADEOLA
-      </Link>
+        <div aria-hidden="true" />
 
-      {/* Desktop links */}
-      <div className="hidden items-center gap-6 md:flex">
-        {links.map(({ id, label }) => {
-          const active = activeId === id
-          return (
-            <a
-              key={id}
-              href={`/#${id}`}
-              aria-current={active ? 'true' : undefined}
-              className={`nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795] ${
-                active ? 'nav-link--active border-b border-white pb-0.5' : ''
+        {/* Desktop links */}
+        <div className="hidden items-center gap-7 md:flex">
+          {links.map(({ id, label }) => {
+            const active = activeId === id
+            return (
+              <a
+                key={id}
+                href={`/#${id}`}
+                aria-current={active ? 'true' : undefined}
+                className={`nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795] ${
+                  active ? 'nav-link--active border-b border-white pb-0.5' : ''
+                }`}
+              >
+                {label}
+              </a>
+            )
+          })}
+          <CTA text="Contact" onClick={() => setContactOpen(true)} />
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
+          aria-controls="mobile-nav"
+          onClick={() => setOpen((v) => !v)}
+          className="relative z-50 flex h-11 w-11 items-center justify-center rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:hidden"
+        >
+          <span className="relative block h-4 w-6">
+            <span
+              className={`absolute left-0 top-0 block h-0.5 w-6 bg-white transition-transform duration-200 ${
+                open ? 'translate-y-[7px] rotate-45' : ''
               }`}
-            >
-              {label}
-            </a>
-          )
-        })}
-        <CTA link="mailto:hello@adeola.com" text="Contact" />
-      </div>
-
-      {/* Mobile hamburger toggle */}
-      <button
-        type="button"
-        aria-label={open ? 'Close menu' : 'Open menu'}
-        aria-expanded={open}
-        aria-controls="mobile-nav"
-        onClick={() => setOpen((v) => !v)}
-        className="md:hidden relative z-50 flex h-11 w-11 items-center justify-center rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-      >
-        <span className="relative block h-4 w-6">
-          <span
-            className={`absolute left-0 top-0 block h-0.5 w-6 bg-white transition-transform duration-200 ${
-              open ? 'translate-y-[7px] rotate-45' : ''
-            }`}
-          />
-          <span
-            className={`absolute left-0 top-[7px] block h-0.5 w-6 bg-white transition-opacity duration-200 ${
-              open ? 'opacity-0' : 'opacity-100'
-            }`}
-          />
-          <span
-            className={`absolute left-0 top-[14px] block h-0.5 w-6 bg-white transition-transform duration-200 ${
-              open ? '-translate-y-[7px] -rotate-45' : ''
-            }`}
-          />
-        </span>
-      </button>
+            />
+            <span
+              className={`absolute left-0 top-[7px] block h-0.5 w-6 bg-white transition-opacity duration-200 ${
+                open ? 'opacity-0' : 'opacity-100'
+              }`}
+            />
+            <span
+              className={`absolute left-0 top-[14px] block h-0.5 w-6 bg-white transition-transform duration-200 ${
+                open ? '-translate-y-[7px] -rotate-45' : ''
+              }`}
+            />
+          </span>
+        </button>
+      </nav>
 
       {/* Mobile drawer */}
       <div
         id="mobile-nav"
-        className={`fixed inset-0 z-40 md:hidden transition-opacity duration-200 ${
+        className={`fixed inset-0 z-40 transition-opacity duration-200 md:hidden ${
           open ? 'opacity-100' : 'pointer-events-none opacity-0'
         }`}
         aria-hidden={!open}
@@ -155,7 +152,7 @@ export default function Nav() {
                 href={`/#${id}`}
                 onClick={() => setOpen(false)}
                 aria-current={active ? 'true' : undefined}
-                className={`text-3xl sm:text-4xl font-bold uppercase tracking-widest rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${
+                className={`rounded-sm text-3xl font-bold uppercase tracking-widest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white sm:text-4xl ${
                   active ? 'text-white' : 'text-white/60'
                 }`}
               >
@@ -164,10 +161,18 @@ export default function Nav() {
             )
           })}
           <div className="pt-4">
-            <CTA link="mailto:hello@adeola.com" text="Contact" />
+            <CTA
+              text="Contact"
+              onClick={() => {
+                setOpen(false)
+                setContactOpen(true)
+              }}
+            />
           </div>
         </div>
       </div>
-    </nav>
+
+      <ContactModal open={contactOpen} onClose={() => setContactOpen(false)} />
+    </>
   )
 }

--- a/app/components/newsletter-form.tsx
+++ b/app/components/newsletter-form.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function NewsletterForm() {
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+
+  function handle(e: React.FormEvent) {
+    e.preventDefault()
+    if (!email) return
+    setSent(true)
+  }
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      <p
+        style={{
+          fontSize: '0.72rem',
+          letterSpacing: '0.18em',
+          color: 'rgba(255,255,255,0.5)',
+          textTransform: 'uppercase',
+        }}
+      >
+        Mailing list
+      </p>
+      {sent ? (
+        <p
+          style={{
+            color: 'rgba(255,255,255,0.55)',
+            fontSize: '0.9rem',
+            borderBottom: '0.5px solid rgba(255,255,255,0.35)',
+            paddingBottom: 10,
+          }}
+        >
+          Thanks — I&apos;ll be in touch.
+        </p>
+      ) : (
+        <form
+          onSubmit={handle}
+          style={{
+            display: 'flex',
+            alignItems: 'stretch',
+            borderBottom: '0.5px solid rgba(255,255,255,0.35)',
+          }}
+        >
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="your@email.com"
+            className="flex-1 bg-transparent py-2.5 text-white outline-none placeholder:text-white/30"
+            style={{
+              border: 'none',
+              fontSize: '0.95rem',
+              letterSpacing: '0.02em',
+              fontFamily: 'inherit',
+            }}
+          />
+          <button
+            type="submit"
+            className="cursor-pointer font-bold uppercase"
+            style={{
+              background: '#fff',
+              color: '#0e2795',
+              border: 'none',
+              fontFamily: 'inherit',
+              fontSize: '0.72rem',
+              letterSpacing: '0.22em',
+              padding: '0 18px',
+            }}
+          >
+            Join
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -1,116 +1,48 @@
-import Image from 'next/image'
-import { PortableText } from '@portabletext/react'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor, hasAsset } from '@/sanity/lib/image'
+import CTA from '../cta'
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
-  title,
-  subtitle,
-  mainImage,
-  introShort,
-  introLong
+  introShort
 }`
-
-const portableTextComponents = {
-  types: {
-    image: ({ value }: { value: { asset: object; alt?: string } }) => (
-      <div className="relative my-8 aspect-[4/3] w-full">
-        <Image
-          src={urlFor(value).width(1200).url()}
-          alt={value.alt ?? ''}
-          fill
-          sizes="(min-width: 768px) 50vw, 100vw"
-          className="object-cover"
-        />
-      </div>
-    ),
-  },
-  block: {
-    normal: ({ children }: { children?: React.ReactNode }) => (
-      <p className="mb-4 leading-relaxed text-white/80">{children}</p>
-    ),
-    h2: ({ children }: { children?: React.ReactNode }) => (
-      <h2 className="mt-10 mb-3 text-xl md:text-2xl font-medium text-white">
-        {children}
-      </h2>
-    ),
-    h3: ({ children }: { children?: React.ReactNode }) => (
-      <h3 className="mt-8 mb-2 text-lg md:text-xl font-medium text-white">
-        {children}
-      </h3>
-    ),
-    blockquote: ({ children }: { children?: React.ReactNode }) => (
-      <blockquote className="my-8 border-l-2 border-white/30 pl-5 italic">
-        <span className="text-gradient-pink-blue text-xl md:text-2xl font-medium leading-snug">
-          {children}
-        </span>
-      </blockquote>
-    ),
-  },
-  marks: {
-    strong: ({ children }: { children?: React.ReactNode }) => (
-      <strong className="font-medium text-white">{children}</strong>
-    ),
-    em: ({ children }: { children?: React.ReactNode }) => (
-      <em className="italic">{children}</em>
-    ),
-    link: ({
-      value,
-      children,
-    }: {
-      value?: { href: string }
-      children?: React.ReactNode
-    }) => (
-      <a
-        href={value?.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="rounded-sm text-white underline underline-offset-4 transition-colors hover:text-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-      >
-        {children}
-      </a>
-    ),
-  },
-}
 
 export default async function AboutSection() {
   const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
 
   return (
-    <section id="about" className="scroll-mt-24">
-      <div className="flex items-baseline gap-2">
-        <p className="display-section">About</p>
-      </div>
-
-      <div className="mt-6 md:mt-8 grid grid-cols-1 items-start gap-10 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] md:gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-20">
-        {hasAsset(general?.mainImage) && (
-          <div className="relative aspect-[3/4] w-full max-w-md md:max-w-none md:sticky md:top-8">
-            <Image
-              src={urlFor(general.mainImage).width(1000).url()}
-              alt={general.mainImage.alt ?? ''}
-              fill
-              sizes="(min-width: 1024px) 40vw, (min-width: 768px) 40vw, 90vw"
-              className="object-cover mix-blend-lighten"
-            />
-          </div>
-        )}
-
+    <section id="about" className="scroll-mt-24 pt-10 pb-[60px]">
+      <div
+        style={{
+          border: '1px solid rgba(255,255,255,0.7)',
+          borderRadius: 12,
+          padding: 'clamp(20px, 4vw, 36px)',
+          display: 'grid',
+          gap: 18,
+        }}
+      >
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: 'clamp(1.4rem, 3vw, 2rem)',
+            letterSpacing: '0.1em',
+          }}
+        >
+          ABOUT
+        </div>
+        <p
+          style={{
+            fontSize: '1rem',
+            fontWeight: 500,
+            letterSpacing: '0.005em',
+            lineHeight: 1.55,
+            margin: 0,
+            color: 'rgba(255,255,255,0.82)',
+            maxWidth: 720,
+          }}
+        >
+          {general?.introShort ?? ''}
+        </p>
         <div>
-          {general?.title && (
-            <p className="label-role mb-6">{general.title}</p>
-          )}
-          {general?.introLong ? (
-            <PortableText
-              value={general.introLong}
-              components={portableTextComponents}
-            />
-          ) : general?.introShort ? (
-            <p className="body-text text-white/80 md:text-lg md:leading-relaxed">
-              {general.introShort}
-            </p>
-          ) : (
-            <p className="text-sm text-white/60">No bio yet.</p>
-          )}
+          <CTA link="#about" text="Read full bio" />
         </div>
       </div>
     </section>

--- a/app/components/sections/audio-section.tsx
+++ b/app/components/sections/audio-section.tsx
@@ -1,92 +1,151 @@
 import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
+import CTA from '../cta'
 
 type Track = {
   _id: string
   title: string
   subtitle?: string
-  audio?: { asset: { url: string } }
   coverImage?: { asset: object; alt?: string }
 }
 
-const AUDIO_QUERY = `*[_type == "audio"] | order(_createdAt desc){
-  _id,
-  title,
-  subtitle,
-  audio { asset->{ url } },
-  coverImage
+type Social = { social: string; url: string }
+
+const MUSIC_QUERY = `{
+  "track": *[_type == "audio"] | order(_createdAt desc)[0]{
+    _id, title, subtitle, coverImage
+  },
+  "general": *[_type == "general"][0]{
+    socials[]{ social, url }
+  }
 }`
 
 export default async function AudioSection() {
-  const { data: tracks } = await sanityFetch({ query: AUDIO_QUERY })
-  const trackList: Track[] = tracks ?? []
+  const { data } = await sanityFetch({ query: MUSIC_QUERY })
+  const track = data?.track as Track | null
+  const socials: Social[] = data?.general?.socials ?? []
+
+  const spotifyLink = socials.find((s) =>
+    s.social.toLowerCase() === 'spotify'
+  )?.url
+
+  const otherStreaming = socials
+    .filter((s) => {
+      const n = s.social.toLowerCase()
+      return n === 'apple music' || n === 'bandcamp' || n === 'tidal'
+    })
+    .map((s) => s.social.toUpperCase())
+
+  if (!track) return null
 
   return (
-    <section id="audio" className="scroll-mt-24">
-      <div className="flex items-baseline gap-2">
-        <p className="display-section">Audio</p>
-        <span className="text-gradient-gold text-sm md:text-base font-bold">
-          ({trackList.length})
-        </span>
+    <section id="music" className="scroll-mt-24 pt-10 pb-[60px]">
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: 8,
+        }}
+      >
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: 'clamp(2rem, 5vw, 3rem)',
+            letterSpacing: '0.1em',
+            lineHeight: 1,
+          }}
+        >
+          MUSIC
+        </div>
+      </div>
+      <div
+        style={{
+          fontSize: '0.72rem',
+          letterSpacing: '0.26em',
+          color: 'rgba(255,255,255,0.6)',
+          marginBottom: 20,
+        }}
+      >
+        NEW RELEASE
       </div>
 
-      <div className="mt-6 md:mt-8">
-        {trackList.length > 0 ? (
-          <div className="flex flex-col">
-            {trackList.map((track) => (
-              <article
-                key={track._id}
-                className="flex flex-col gap-5 border-t border-white/20 py-6 md:flex-row md:items-center md:gap-8 md:py-8"
-              >
-                <div className="flex items-center gap-5 md:gap-6 md:flex-1">
-                  {hasAsset(track.coverImage) ? (
-                    <div className="relative h-20 w-20 shrink-0 md:h-24 md:w-24 lg:h-28 lg:w-28">
-                      <Image
-                        src={urlFor(track.coverImage).width(400).url()}
-                        alt={track.coverImage.alt ?? track.title}
-                        fill
-                        sizes="(min-width: 1024px) 112px, (min-width: 768px) 96px, 80px"
-                        className="object-cover"
-                      />
-                    </div>
-                  ) : (
-                    <div className="h-20 w-20 shrink-0 bg-white/5 md:h-24 md:w-24 lg:h-28 lg:w-28" />
-                  )}
-                  <div className="flex flex-col gap-1">
-                    <p className="show-title text-white">{track.title}</p>
-                    {track.subtitle && (
-                      <p className="text-sm tracking-wide text-white/60">
-                        {track.subtitle}
-                      </p>
-                    )}
-                  </div>
-                </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(160px, 220px) 1fr',
+          gap: 28,
+          alignItems: 'center',
+        }}
+      >
+        {/* EP cover */}
+        <div
+          style={{
+            aspectRatio: '1/1',
+            overflow: 'hidden',
+            background: 'rgba(255,255,255,0.06)',
+            position: 'relative',
+          }}
+        >
+          {hasAsset(track.coverImage) ? (
+            <Image
+              src={urlFor(track.coverImage).width(440).url()}
+              alt={(track.coverImage as { alt?: string }).alt ?? track.title}
+              fill
+              sizes="220px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="h-full w-full bg-white/5" />
+          )}
+        </div>
 
-                <div className="md:flex-1 md:max-w-md">
-                  {track.audio?.asset?.url ? (
-                    <div className="rounded-full bg-white/5 p-2">
-                      <audio
-                        controls
-                        src={track.audio.asset.url}
-                        aria-label={`Play ${track.title}`}
-                        className="h-10 w-full"
-                      />
-                    </div>
-                  ) : (
-                    <p className="text-sm text-white/40">
-                      No audio file uploaded.
-                    </p>
-                  )}
-                </div>
-              </article>
-            ))}
+        {/* EP info */}
+        <div className="flex flex-col gap-2.5">
+          <div
+            style={{
+              fontSize: 'clamp(2rem, 5vw, 3.4rem)',
+              fontWeight: 700,
+              letterSpacing: '-0.03em',
+              lineHeight: 0.95,
+              textTransform: 'uppercase',
+            }}
+          >
+            {track.title}
           </div>
-        ) : (
-          <p className="border-t border-white/20 pt-5 text-sm text-white/60">
-            No tracks yet.
-          </p>
-        )}
+          {track.subtitle && (
+            <div
+              style={{
+                fontSize: '0.82rem',
+                letterSpacing: '0.2em',
+                color: 'rgba(255,255,255,0.6)',
+                textTransform: 'uppercase',
+              }}
+            >
+              {track.subtitle}
+            </div>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-2.5">
+            {spotifyLink ? (
+              <CTA link={spotifyLink} text="Listen on Spotify" external />
+            ) : (
+              <CTA link="#music" text="Listen" />
+            )}
+            {otherStreaming.length > 0 && (
+              <span
+                style={{
+                  fontSize: '0.8rem',
+                  color: 'rgba(255,255,255,0.6)',
+                  letterSpacing: '0.15em',
+                  alignSelf: 'center',
+                }}
+              >
+                {otherStreaming.join(' · ')}
+              </span>
+            )}
+          </div>
+        </div>
       </div>
     </section>
   )

--- a/app/components/sections/shows-section.tsx
+++ b/app/components/sections/shows-section.tsx
@@ -1,7 +1,4 @@
-import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
-import { urlFor, hasAsset } from '@/sanity/lib/image'
-import CTA from '../cta'
 
 type Ticket = { venue: string; url: string }
 
@@ -12,7 +9,6 @@ type Show = {
   date?: string
   live: boolean
   tickets?: Ticket[]
-  mainImage?: { asset: object; alt?: string }
 }
 
 const SHOWS_QUERY = `*[_type == "show"] | order(date asc){
@@ -21,166 +17,179 @@ const SHOWS_QUERY = `*[_type == "show"] | order(date asc){
   subtitle,
   date,
   live,
-  tickets,
-  mainImage
-}`
-
-const GENERAL_QUERY = `*[_type == "general"][0]{
-  mainImage,
-  introShort
+  tickets[]{ venue, url }
 }`
 
 function formatShowDate(date?: string) {
   if (!date) return null
   const d = new Date(date)
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0')
   const day = String(d.getUTCDate()).padStart(2, '0')
-  const month = d
-    .toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
-    .toUpperCase()
-  const year = d.getUTCFullYear()
-  const hour = String(d.getUTCHours()).padStart(2, '0')
-  const minute = String(d.getUTCMinutes()).padStart(2, '0')
-  return `${day} ${month} ${year} · ${hour}:${minute}`
-}
-
-function ShowRow({ show, muted }: { show: Show; muted?: boolean }) {
-  const location = show.subtitle?.[0]
-  const dateStr = formatShowDate(show.date)
-
-  return (
-    <div
-      className={`border-t border-white/20 py-5 md:py-7 ${
-        muted ? 'opacity-50' : ''
-      }`}
-    >
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
-        {hasAsset(show.mainImage) ? (
-          <div className="relative h-16 w-16 shrink-0 md:h-20 md:w-20">
-            <Image
-              src={urlFor(show.mainImage).width(240).url()}
-              alt={show.mainImage.alt ?? ''}
-              fill
-              sizes="80px"
-              className="object-cover"
-            />
-          </div>
-        ) : null}
-
-        <p className="show-title flex-1 text-white">{show.title}</p>
-
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:min-w-[18rem] md:justify-end">
-          <div className="flex flex-col gap-1 md:text-right">
-            {location && (
-              <p className="text-sm tracking-widest text-white/60">{location}</p>
-            )}
-            {dateStr && (
-              <p className="text-sm tracking-widest text-white/60">{dateStr}</p>
-            )}
-          </div>
-          {show.live && show.tickets && show.tickets[0] && (
-            <div>
-              <CTA link={show.tickets[0].url} text="Tickets" external />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  )
+  return `${month}.${day}`
 }
 
 export default async function ShowsSection() {
   const { data: shows } = await sanityFetch({ query: SHOWS_QUERY })
-  const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
-
-  const upcoming: Show[] = shows?.filter((s: Show) => s.live) ?? []
-  const past: Show[] = shows?.filter((s: Show) => !s.live) ?? []
-  const totalCount = upcoming.length + past.length
+  const upcoming: Show[] = (shows ?? []).filter((s: Show) => s.live)
 
   return (
-    <section id="shows" className="scroll-mt-24">
-      {/* Signature SHOWS giant — the one display-giant moment kept */}
-      <div className="flex items-end justify-between gap-4">
-        <div className="flex items-start gap-2 leading-none">
+    <section id="shows" className="scroll-mt-24 pt-10 pb-[60px]">
+      <div style={{ marginBottom: 20 }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+          }}
+        >
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+            }}
+          >
+            SHOWS
+          </div>
           <span
-            className="display-giant display-giant--xl text-white"
-            style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
+            style={{
+              fontSize: '0.75rem',
+              letterSpacing: '0.2em',
+              color: 'rgba(255,255,255,0.6)',
+            }}
+          >
+            ALL SHOWS →
+          </span>
+        </div>
+        <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'block',
+              fontWeight: 700,
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+              color: 'transparent',
+              userSelect: 'none',
+              pointerEvents: 'none',
+              marginTop: 1,
+              transform: 'scaleY(-1)',
+              backgroundImage:
+                'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+            }}
           >
             SHOWS
           </span>
-          <span className="text-gradient-gold text-lg md:text-2xl font-bold">
-            ({totalCount})
-          </span>
         </div>
       </div>
-      <div className="relative flex flex-col items-start overflow-hidden">
+
+      <div
+        style={{
+          fontSize: '0.72rem',
+          letterSpacing: '0.26em',
+          color: 'rgba(255,255,255,0.6)',
+          marginBottom: 20,
+        }}
+      >
+        UPCOMING{' '}
         <span
-          className="display-giant display-giant--xl reflect whitespace-nowrap"
-          aria-hidden="true"
-          style={{ fontSize: 'clamp(4rem, 14vw, 12.5rem)' }}
+          className="text-gradient-gold"
+          style={{ marginLeft: 4 }}
         >
-          SHOWS
+          ({upcoming.length})
         </span>
       </div>
 
-      {/* Intro */}
-      {(hasAsset(general?.mainImage) || general?.introShort) && (
-        <div className="mt-12 md:mt-16">
-          <div className="flex flex-col gap-6 md:flex-row md:items-end md:gap-10">
-            {hasAsset(general?.mainImage) && (
-              <div className="relative h-60 w-[180px] shrink-0 md:h-[384px] md:w-[329px] lg:h-[520px] lg:w-[420px]">
-                <Image
-                  src={urlFor(general.mainImage).width(900).url()}
-                  alt={general.mainImage.alt ?? ''}
-                  fill
-                  sizes="(min-width: 1024px) 420px, (min-width: 768px) 329px, 180px"
-                  className="object-cover mix-blend-lighten"
-                />
+      <div className="flex flex-col">
+        {upcoming.length === 0 ? (
+          <p
+            style={{
+              borderTop: '1px solid rgba(255,255,255,0.2)',
+              paddingTop: 20,
+              fontSize: '0.875rem',
+              color: 'rgba(255,255,255,0.4)',
+            }}
+          >
+            No upcoming shows at the moment.
+          </p>
+        ) : (
+          upcoming.map((show, i) => {
+            const dateStr = formatShowDate(show.date)
+            const venue = show.subtitle?.[0] ?? show.tickets?.[0]?.venue
+            const ticketUrl = show.tickets?.[0]?.url
+
+            return (
+              <div
+                key={show._id}
+                className="grid items-center gap-x-5 gap-y-2 py-5 sm:gap-x-5"
+                style={{
+                  gridTemplateColumns: '64px 1fr auto',
+                  borderTop: '1px solid rgba(255,255,255,0.2)',
+                  borderBottom:
+                    i === upcoming.length - 1
+                      ? '1px solid rgba(255,255,255,0.2)'
+                      : 'none',
+                  padding: '20px 0',
+                }}
+              >
+                {/* Date */}
+                <div
+                  style={{
+                    fontWeight: 700,
+                    letterSpacing: '0.05em',
+                    fontSize: '1rem',
+                  }}
+                >
+                  {dateStr ?? '—'}
+                </div>
+
+                {/* City + venue */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <div
+                    style={{
+                      fontWeight: 700,
+                      letterSpacing: '0.08em',
+                      fontSize: 'clamp(1rem, 2vw, 1.15rem)',
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    {show.title}
+                  </div>
+                  {venue && (
+                    <div style={{ fontSize: '0.8rem', color: 'rgba(255,255,255,0.6)' }}>
+                      {venue}
+                    </div>
+                  )}
+                </div>
+
+                {/* Tickets */}
+                {ticketUrl ? (
+                  <a
+                    href={ticketUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    style={{
+                      fontSize: '0.75rem',
+                      letterSpacing: '0.2em',
+                      color: 'rgba(255,255,255,0.7)',
+                      textDecoration: 'none',
+                    }}
+                  >
+                    TICKETS →
+                  </a>
+                ) : (
+                  <div />
+                )}
               </div>
-            )}
-            {general?.introShort && (
-              <p className="flex-1 text-2xl font-medium leading-tight text-white md:text-4xl lg:text-5xl lg:leading-[0.95]">
-                {general.introShort}
-              </p>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Upcoming */}
-      <div className="mt-12 md:mt-16 flex w-full flex-col gap-6">
-        <div className="flex items-baseline gap-2">
-          <p className="display-section">Upcoming</p>
-          <span className="text-gradient-gold text-sm md:text-base font-bold">
-            ({upcoming.length})
-          </span>
-        </div>
-        <div className="flex flex-col">
-          {upcoming.length > 0 ? (
-            upcoming.map((show) => <ShowRow key={show._id} show={show} />)
-          ) : (
-            <p className="border-t border-white/20 py-5 text-sm text-white/40">
-              No upcoming shows at the moment.
-            </p>
-          )}
-        </div>
+            )
+          })
+        )}
       </div>
-
-      {/* Past */}
-      {past.length > 0 && (
-        <div className="mt-12 md:mt-16 flex w-full flex-col gap-6">
-          <div className="flex items-baseline gap-2">
-            <p className="display-section">Past</p>
-            <span className="text-sm md:text-base font-bold text-white/60">
-              ({past.length})
-            </span>
-          </div>
-          <div className="flex flex-col">
-            {past.map((show) => (
-              <ShowRow key={show._id} show={show} muted />
-            ))}
-          </div>
-        </div>
-      )}
     </section>
   )
 }

--- a/app/components/sections/video-section.tsx
+++ b/app/components/sections/video-section.tsx
@@ -7,7 +7,6 @@ type Video = {
   _id: string
   title: string
   subtitle?: string[]
-  date?: string
   thumbnail?: { asset: object; alt?: string }
   videourl: string
 }
@@ -16,138 +15,282 @@ const VIDEO_QUERY = `*[_type == "video"] | order(date desc){
   _id,
   title,
   subtitle,
-  date,
   thumbnail,
   videourl
 }`
 
-function formatDate(date?: string) {
-  if (!date) return null
-  const d = new Date(date)
-  const day = String(d.getUTCDate()).padStart(2, '0')
-  const month = d
-    .toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
-    .toUpperCase()
-  const year = d.getUTCFullYear()
-  return `${day} ${month} ${year}`
-}
-
-function VideoCard({ video, featured }: { video: Video; featured?: boolean }) {
-  return (
-    <Link
-      href={video.videourl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-    >
-      <div className="relative aspect-video w-full overflow-hidden bg-white/5">
-        {hasAsset(video.thumbnail) ? (
-          <Image
-            src={urlFor(video.thumbnail)
-              .width(featured ? 1600 : 900)
-              .url()}
-            alt={(video.thumbnail as { alt?: string }).alt ?? video.title}
-            fill
-            sizes={
-              featured
-                ? '(min-width: 1024px) 1280px, 100vw'
-                : '(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw'
-            }
-            className="object-cover transition-opacity duration-300 group-hover:opacity-70"
-          />
-        ) : (
-          <div className="h-full w-full bg-white/5" />
-        )}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div
-            className={`flex items-center justify-center rounded-full bg-white/10 transition-colors duration-300 group-hover:bg-white/20 ${
-              featured ? 'h-14 w-14 md:h-16 md:w-16' : 'h-12 w-12 md:h-14 md:w-14'
-            }`}
-          >
-            <svg
-              width="14"
-              height="16"
-              viewBox="0 0 8 9"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
-            </svg>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <p className="show-title text-white">{video.title}</p>
-        {video.subtitle && video.subtitle.length > 0 && (
-          <p className="text-sm tracking-wide text-white/60">
-            {video.subtitle.join(' · ')}
-          </p>
-        )}
-        {video.date && (
-          <p className="text-micro mt-1 text-white/60">
-            {formatDate(video.date)}
-          </p>
-        )}
-      </div>
-    </Link>
-  )
-}
-
 export default async function VideoSection() {
   const { data: videos } = await sanityFetch({ query: VIDEO_QUERY })
   const list: Video[] = videos ?? []
-
   const featured = list[0]
   const rest = list.slice(1)
 
-  const groups = new Map<string, Video[]>()
-  for (const v of rest) {
-    const year = v.date ? String(new Date(v.date).getUTCFullYear()) : '—'
-    if (!groups.has(year)) groups.set(year, [])
-    groups.get(year)!.push(v)
-  }
-
   return (
-    <section id="video" className="scroll-mt-24">
-      <div className="flex items-baseline gap-2">
-        <p className="display-section">Video</p>
-        <span className="text-gradient-gold text-sm md:text-base font-bold">
-          ({list.length})
-        </span>
+    <section id="video" className="scroll-mt-24 pt-10 pb-[60px]">
+      <div style={{ marginBottom: 20 }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+          }}
+        >
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+            }}
+          >
+            VIDEOS
+          </div>
+          <span
+            style={{
+              fontSize: '0.75rem',
+              letterSpacing: '0.2em',
+              color: 'rgba(255,255,255,0.6)',
+            }}
+          >
+            ALL VIDEOS →
+          </span>
+        </div>
+        <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'block',
+              fontWeight: 700,
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+              color: 'transparent',
+              userSelect: 'none',
+              pointerEvents: 'none',
+              marginTop: 1,
+              transform: 'scaleY(-1)',
+              backgroundImage:
+                'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+            }}
+          >
+            VIDEOS
+          </span>
+        </div>
       </div>
 
-      {list.length > 0 ? (
-        <div className="mt-6 md:mt-8 flex flex-col gap-12 md:gap-16">
-          {featured && <VideoCard video={featured} featured />}
-
-          {rest.length > 0 && (
-            <div className="flex flex-col gap-12 md:gap-16">
-              {Array.from(groups.entries()).map(([year, items]) => (
-                <div key={year} className="flex flex-col gap-6 md:gap-8">
-                  <div className="flex items-baseline gap-3 border-b border-white/20 pb-3">
-                    <p className="text-base font-bold tracking-widest text-white">
-                      {year}
-                    </p>
-                    <span className="text-sm text-white/40 tracking-widest">
-                      ({items.length})
-                    </span>
-                  </div>
-                  <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-                    {items.map((video) => (
-                      <VideoCard key={video._id} video={video} />
-                    ))}
+      {list.length === 0 ? (
+        <p
+          style={{
+            borderTop: '1px solid rgba(255,255,255,0.2)',
+            paddingTop: 20,
+            fontSize: '0.875rem',
+            color: 'rgba(255,255,255,0.4)',
+          }}
+        >
+          No videos yet.
+        </p>
+      ) : (
+        <>
+          {/* Featured video */}
+          {featured && (
+            <>
+              <Link
+                href={featured.videourl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                style={{ marginBottom: 12 }}
+              >
+                <div
+                  style={{
+                    position: 'relative',
+                    aspectRatio: '16/9',
+                    background: 'rgba(255,255,255,0.06)',
+                    overflow: 'hidden',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {hasAsset(featured.thumbnail) && (
+                    <Image
+                      src={urlFor(featured.thumbnail).width(1600).url()}
+                      alt={
+                        (featured.thumbnail as { alt?: string }).alt ??
+                        featured.title
+                      }
+                      fill
+                      sizes="(min-width: 1024px) 960px, 100vw"
+                      className="object-cover"
+                      style={{ opacity: 0.6 }}
+                    />
+                  )}
+                  <div
+                    style={{
+                      position: 'relative',
+                      width: 68,
+                      height: 68,
+                      borderRadius: '50%',
+                      background: 'rgba(255,255,255,0.16)',
+                      backdropFilter: 'blur(6px)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      zIndex: 1,
+                    }}
+                  >
+                    <svg
+                      width="18"
+                      height="19"
+                      viewBox="0 0 8 9"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
+                    </svg>
                   </div>
                 </div>
+              </Link>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'baseline',
+                  marginBottom: 24,
+                }}
+              >
+                <div
+                  style={{
+                    fontWeight: 700,
+                    letterSpacing: '0.1em',
+                    fontSize: '0.95rem',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {featured.title}
+                </div>
+                {featured.subtitle && featured.subtitle.length > 0 && (
+                  <div
+                    style={{
+                      fontSize: '0.75rem',
+                      color: 'rgba(255,255,255,0.6)',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    {featured.subtitle.join(' · ')}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Video grid */}
+          {rest.length > 0 && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                gap: 14,
+              }}
+            >
+              {rest.map((v) => (
+                <Link
+                  key={v._id}
+                  href={v.videourl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex flex-col gap-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                >
+                  <div
+                    style={{
+                      aspectRatio: '16/10',
+                      background: 'rgba(255,255,255,0.08)',
+                      position: 'relative',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {hasAsset(v.thumbnail) && (
+                      <Image
+                        src={urlFor(v.thumbnail).width(600).url()}
+                        alt={
+                          (v.thumbnail as { alt?: string }).alt ?? v.title
+                        }
+                        fill
+                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                        className="object-cover"
+                        style={{ opacity: 0.7 }}
+                      />
+                    )}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        background:
+                          'linear-gradient(135deg, rgba(255,206,229,0.08), rgba(0,47,109,0.6))',
+                      }}
+                    />
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '50%',
+                        transform: 'translate(-50%,-50%)',
+                        width: 38,
+                        height: 38,
+                        borderRadius: '50%',
+                        background: 'rgba(255,255,255,0.14)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <svg
+                        width="10"
+                        height="11"
+                        viewBox="0 0 8 9"
+                        fill="none"
+                        aria-hidden="true"
+                      >
+                        <path d="M8 4.5L0 9L0 0L8 4.5Z" fill="white" />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'baseline',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: '0.78rem',
+                        fontWeight: 700,
+                        letterSpacing: '0.1em',
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      {v.title}
+                    </div>
+                    {v.subtitle && v.subtitle.length > 0 && (
+                      <div
+                        style={{
+                          fontSize: '0.68rem',
+                          color: 'rgba(255,255,255,0.55)',
+                        }}
+                      >
+                        {v.subtitle.join(' · ')}
+                      </div>
+                    )}
+                  </div>
+                </Link>
               ))}
             </div>
           )}
-        </div>
-      ) : (
-        <p className="mt-6 border-t border-white/20 pt-5 text-sm text-white/60">
-          No videos yet.
-        </p>
+        </>
       )}
     </section>
   )

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,65 +1,266 @@
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
+import NewsletterForm from './newsletter-form'
 
 type Social = { social: string; url: string }
-
-type General = {
-  socials?: Social[]
-  phone?: string
-  email?: string
-}
+type General = { socials?: Social[] }
 
 const FOOTER_QUERY = `*[_type == "general"][0]{
-  socials[]{ social, url },
-  phone,
-  email
+  socials[]{ social, url }
 }`
+
+const SOCIAL_ICONS: Record<string, React.ReactNode> = {
+  instagram: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+      <circle cx="12" cy="12" r="5" />
+      <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+  spotify: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4.586 14.424a.622.622 0 0 1-.857.207c-2.348-1.435-5.304-1.76-8.785-.964a.622.622 0 1 1-.277-1.215c3.809-.87 7.076-.496 9.712 1.115.294.181.387.564.207.857zm1.223-2.722a.78.78 0 0 1-1.072.258c-2.687-1.652-6.785-2.13-9.965-1.165a.78.78 0 0 1-.973-.519.781.781 0 0 1 .519-.972c3.632-1.102 8.147-.568 11.234 1.326a.78.78 0 0 1 .257 1.072zm.105-2.835C14.692 8.95 9.375 8.775 6.297 9.71a.937.937 0 1 1-.543-1.794c3.514-1.066 9.354-.86 13.045 1.345a.937.937 0 0 1-.885 1.606z" />
+    </svg>
+  ),
+  'apple music': (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M23 6.998v9.01c0 2.76-2.24 5-5 5H6c-2.76 0-5-2.24-5-5v-9.01c0-2.76 2.24-5 5-5h12c2.76 0 5 2.24 5 5zm-6.987-1.02L9.96 7.808v5.99c-.327-.094-.672-.149-1.03-.149-1.768 0-3.2 1.19-3.2 2.66s1.432 2.66 3.2 2.66 3.2-1.19 3.2-2.66V9.62l4.053-1.365v4.533c-.327-.094-.672-.149-1.03-.149-1.768 0-3.2 1.19-3.2 2.66s1.432 2.66 3.2 2.66S18.353 16.76 18.353 15.3V7.408l-2.34.57z" />
+    </svg>
+  ),
+  youtube: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    </svg>
+  ),
+  tiktok: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1V9.01a6.33 6.33 0 0 0-.79-.05 6.34 6.34 0 0 0-6.34 6.34 6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.33-6.34V8.95a8.28 8.28 0 0 0 4.84 1.54V7.03a4.85 4.85 0 0 1-1.07-.34z" />
+    </svg>
+  ),
+  bandcamp: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M0 18.75l7.437-13.5H24l-7.438 13.5z" />
+    </svg>
+  ),
+  twitter: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.74l7.73-8.835L1.254 2.25H8.08l4.213 5.567 5.95-5.567zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  ),
+}
 
 export default async function SiteFooter() {
   const { data } = await sanityFetch({ query: FOOTER_QUERY })
   const general = (data ?? {}) as General
   const socials = general.socials ?? []
-  const hasContact = Boolean(general.phone || general.email)
 
   return (
-    <footer className="flex flex-col gap-4 border-t border-white pt-6 pb-8">
+    <footer
+      className="flex flex-col"
+      style={{ gap: 44, paddingTop: 60, paddingBottom: 20 }}
+    >
+      {/* Newsletter */}
+      <div
+        id="newsletter"
+        style={{
+          borderTop: '1px solid rgba(255,255,255,0.25)',
+          paddingTop: 36,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+            }}
+          >
+            NEWSLETTER
+          </div>
+          <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+            <span
+              aria-hidden="true"
+              style={{
+                display: 'block',
+                fontWeight: 700,
+                fontSize: 'clamp(2rem, 5vw, 3rem)',
+                letterSpacing: '0.1em',
+                lineHeight: 1,
+                color: 'transparent',
+                userSelect: 'none',
+                pointerEvents: 'none',
+                marginTop: 1,
+                transform: 'scaleY(-1)',
+                backgroundImage:
+                  'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+              }}
+            >
+              NEWSLETTER
+            </span>
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+            gap: 36,
+            alignItems: 'start',
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 'clamp(1.3rem, 3vw, 1.8rem)',
+                fontWeight: 500,
+                letterSpacing: '-0.01em',
+                lineHeight: 1.1,
+                marginBottom: 10,
+              }}
+            >
+              Letters from the studio.
+            </div>
+            <div
+              style={{
+                fontSize: '0.85rem',
+                color: 'rgba(255,255,255,0.6)',
+                lineHeight: 1.5,
+                maxWidth: 360,
+              }}
+            >
+              Mostly quiet. A handful of times a year.
+            </div>
+          </div>
+          <NewsletterForm />
+        </div>
+      </div>
+
+      {/* Social icons */}
       {socials.length > 0 && (
-        <div className="flex flex-wrap gap-x-8 gap-y-3 px-3">
-          {socials.map((s) => (
-            <Link
-              key={s.social}
-              href={s.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-sm py-1 text-sm md:text-base font-bold uppercase tracking-widest text-white transition-colors duration-200 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              {s.social}
-            </Link>
-          ))}
+        <div
+          style={{
+            borderTop: '1px solid rgba(255,255,255,0.2)',
+            paddingTop: 28,
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 24,
+            alignItems: 'center',
+          }}
+        >
+          {socials.map((s) => {
+            const key = s.social.toLowerCase()
+            const icon = SOCIAL_ICONS[key]
+            return (
+              <Link
+                key={s.social}
+                href={s.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={s.social}
+                className="flex items-center justify-center text-white transition-colors duration-200 hover:text-white/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                style={{ width: 52, height: 52 }}
+              >
+                {icon ? (
+                  <span
+                    style={{ width: 32, height: 32, display: 'flex' }}
+                    aria-hidden="true"
+                  >
+                    {icon}
+                  </span>
+                ) : (
+                  <span
+                    style={{
+                      fontSize: '0.7rem',
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      fontWeight: 700,
+                    }}
+                  >
+                    {s.social}
+                  </span>
+                )}
+              </Link>
+            )
+          })}
         </div>
       )}
-      {hasContact && (
-        <div className="flex flex-wrap gap-x-8 gap-y-2 px-3">
-          {general.email && (
-            <a
-              href={`mailto:${general.email}`}
-              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              {general.email}
-            </a>
-          )}
-          {general.phone && (
-            <a
-              href={`tel:${general.phone.replace(/\s+/g, '')}`}
-              className="nav-link rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              {general.phone}
-            </a>
-          )}
+
+      {/* Wordmark + reflection */}
+      <div className="-mx-5 md:-mx-10">
+        {/* Main wordmark */}
+        <div style={{ textAlign: 'center' }}>
+          <span
+            style={{
+              display: 'block',
+              fontWeight: 700,
+              fontSize: 'clamp(5rem, 24vw, 17rem)',
+              letterSpacing: '-0.055em',
+              color: '#fff',
+              userSelect: 'none',
+              lineHeight: 0.92,
+            }}
+          >
+            ADEOLA
+          </span>
         </div>
-      )}
-      <div className="px-3 pt-2">
-        <p className="text-micro">cc. Adeola Ikuesan 2026</p>
+        {/* Reflection — scaleY(-1) from default center origin keeps content within
+            its layout bounds; gradient "to top" in pre-flip space becomes bright-at-top
+            after flip, giving a fade that's strongest near the join */}
+        <div
+          style={{
+            textAlign: 'center',
+            height: 'clamp(3rem, 10vw, 8rem)',
+            overflow: 'hidden',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'block',
+              fontWeight: 700,
+              fontSize: 'clamp(5rem, 24vw, 17rem)',
+              letterSpacing: '-0.055em',
+              lineHeight: 0.92,
+              color: 'transparent',
+              userSelect: 'none',
+              pointerEvents: 'none',
+              marginTop: 2,
+              transform: 'scaleY(-1)',
+              backgroundImage:
+                'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+            }}
+          >
+            ADEOLA
+          </span>
+        </div>
+      </div>
+
+      {/* Copyright */}
+      <div
+        style={{
+          textAlign: 'center',
+          paddingBottom: 28,
+          fontSize: '0.72rem',
+          letterSpacing: '0.24em',
+          color: 'rgba(255,255,255,0.55)',
+        }}
+      >
+        cc. Adeola Ikuesan 2026
       </div>
     </footer>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -75,9 +75,9 @@ body {
 }
 
 h1 {
-  font-size: clamp(2.3328rem, 1.7715rem + 2.8067vw, 3.9467rem);
-  line-height: 1;
-  letter-spacing: -0.025em;
+  font-size: clamp(3.2rem, 11vw, 7.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.035em;
   font-weight: 700;
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { urlFor, hasAsset } from '@/sanity/lib/image'
 import CTA from './components/cta'
 import SiteFooter from './components/site-footer'
 import ShowsSection from './components/sections/shows-section'
-import AudioSection from './components/sections/audio-section'
 import VideoSection from './components/sections/video-section'
 import AboutSection from './components/sections/about-section'
 
@@ -12,7 +11,6 @@ const HERO_QUERY = `*[_type == "general"][0]{
   title,
   subtitle,
   mainImage,
-  profileImage,
   introShort
 }`
 
@@ -20,66 +18,71 @@ export default async function Home() {
   const { data: general } = await sanityFetch({ query: HERO_QUERY })
 
   return (
-    <div className="flex flex-col gap-20 md:gap-32">
+    <div>
       {/* Hero */}
-      <section className="relative pt-16 md:pt-24">
-        <div className="grid gap-8 md:grid-cols-2 md:items-center md:gap-10">
-          <div className="flex flex-col items-start">
-            <div className="label-role mb-2 flex gap-3 px-1">
-              <span>SINGER</span>
-              <span aria-hidden="true">•</span>
-              <span>SONGWRITER</span>
-            </div>
-            <h1 className="font-bold leading-none tracking-tight">
-              {general?.title ?? 'ADEOLA'}
-            </h1>
-            <div className="mt-5">
-              <CTA link="#audio" text="EP OUT NOW" />
-            </div>
-          </div>
-
-          {hasAsset(general?.mainImage) && (
-            <div className="relative mx-auto aspect-square w-full max-w-sm md:max-w-none md:-mt-8">
-              <Image
-                src={urlFor(general.mainImage).width(900).url()}
-                alt={general.mainImage.alt ?? ''}
-                fill
-                sizes="(min-width: 768px) 50vw, 90vw"
-                className="object-cover mix-blend-lighten"
-                priority
-              />
-            </div>
-          )}
+      <section className="pt-10 pb-10">
+        <div
+          style={{
+            display: 'flex',
+            gap: 10,
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: '0.85rem',
+            letterSpacing: '0.04em',
+            marginBottom: 12,
+            textTransform: 'uppercase',
+          }}
+        >
+          <span>SINGER</span>
+          <span aria-hidden="true">•</span>
+          <span>SONGWRITER</span>
         </div>
+
+        <h1 className="m-0 mb-7 uppercase">
+          {general?.title ?? 'ADEOLA'}
+        </h1>
+
+        <div className="mb-2.5">
+          <CTA link="#music" text={general?.subtitle ?? 'EP OUT NOW'} />
+        </div>
+
+        {hasAsset(general?.mainImage) && (
+          <div
+            className="relative mx-auto max-w-[480px]"
+            style={{ marginTop: -30, aspectRatio: '3/4' }}
+          >
+            <Image
+              src={urlFor(general.mainImage).width(960).url()}
+              alt={general.mainImage.alt ?? ''}
+              fill
+              sizes="(min-width: 768px) 480px, 100vw"
+              className="object-contain mix-blend-lighten"
+              priority
+            />
+          </div>
+        )}
       </section>
 
       {/* Bio quote */}
       {general?.introShort && (
-        <section>
-          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] items-center gap-5 md:gap-12">
-            {hasAsset(general?.profileImage) && (
-              <div className="relative aspect-[3/4] w-full">
-                <Image
-                  src={urlFor(general.profileImage).width(700).url()}
-                  alt={general.profileImage.alt ?? ''}
-                  fill
-                  sizes="(min-width: 768px) 33vw, 35vw"
-                  className="object-cover"
-                />
-              </div>
-            )}
-            <p className="text-gradient-pink-blue text-xl font-medium tracking-wide leading-snug sm:text-2xl md:text-4xl md:leading-tight">
-              {general.introShort}
-            </p>
-          </div>
+        <section className="pt-5 pb-[60px]">
+          <p
+            className="text-gradient-pink-blue m-0"
+            style={{
+              fontSize: 'clamp(1.3rem, 3.2vw, 2rem)',
+              fontWeight: 500,
+              letterSpacing: '0.01em',
+              lineHeight: 1.2,
+              maxWidth: 780,
+            }}
+          >
+            {general.introShort}
+          </p>
         </section>
       )}
 
-      <ShowsSection />
-      <AudioSection />
       <VideoSection />
+      <ShowsSection />
       <AboutSection />
-
       <SiteFooter />
     </div>
   )


### PR DESCRIPTION
Implements the full single-page portfolio spec:
- New container width (1040px), updated h1 fluid sizing
- Nav: removes wordmark, adds Contact modal trigger, updates links
- Hero: stacked layout with IKUESAN h1 and ghost image
- Bio quote: gradient text only (no profile image)
- Shows/Videos sections: redesigned with section headings + reflection effect
- About: bordered card layout
- Footer: newsletter form, social icons, ADEOLA wordmark + reflection
- New components: ContactModal, NewsletterForm
- CTA extended to support button/submit mode
- Reflection effect applied to SHOWS, VIDEOS, NEWSLETTER, and ADEOLA headings