### PR TITLE
feat: refine spacing, reflection, and component styling

### DIFF
--- a/app/components/newsletter-form.tsx
+++ b/app/components/newsletter-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import CTA from './cta'
 
 export default function NewsletterForm() {
   const [email, setEmail] = useState('')
@@ -12,69 +13,47 @@ export default function NewsletterForm() {
     setSent(true)
   }
 
-  return (
-    <div className="flex flex-col gap-3.5">
+  if (sent) {
+    return (
       <p
         style={{
-          fontSize: '0.72rem',
-          letterSpacing: '0.18em',
-          color: 'rgba(255,255,255,0.5)',
-          textTransform: 'uppercase',
+          color: 'rgba(255,255,255,0.55)',
+          fontSize: '0.9rem',
+          borderBottom: '0.5px solid rgba(255,255,255,0.35)',
+          paddingBottom: 10,
         }}
       >
-        Mailing list
+        Thanks — I&apos;ll be in touch.
       </p>
-      {sent ? (
-        <p
-          style={{
-            color: 'rgba(255,255,255,0.55)',
-            fontSize: '0.9rem',
-            borderBottom: '0.5px solid rgba(255,255,255,0.35)',
-            paddingBottom: 10,
-          }}
-        >
-          Thanks — I&apos;ll be in touch.
-        </p>
-      ) : (
-        <form
-          onSubmit={handle}
-          style={{
-            display: 'flex',
-            alignItems: 'stretch',
-            borderBottom: '0.5px solid rgba(255,255,255,0.35)',
-          }}
-        >
-          <input
-            type="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="your@email.com"
-            className="flex-1 bg-transparent py-2.5 text-white outline-none placeholder:text-white/30"
-            style={{
-              border: 'none',
-              fontSize: '0.95rem',
-              letterSpacing: '0.02em',
-              fontFamily: 'inherit',
-            }}
-          />
-          <button
-            type="submit"
-            className="cursor-pointer font-bold uppercase"
-            style={{
-              background: '#fff',
-              color: '#0e2795',
-              border: 'none',
-              fontFamily: 'inherit',
-              fontSize: '0.72rem',
-              letterSpacing: '0.22em',
-              padding: '0 18px',
-            }}
-          >
-            Join
-          </button>
-        </form>
-      )}
-    </div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handle}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        borderBottom: '0.5px solid rgba(255,255,255,0.35)',
+        paddingBottom: 8,
+      }}
+    >
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="your@email.com"
+        className="min-w-0 flex-1 bg-transparent py-2.5 text-white outline-none placeholder:text-white/30"
+        style={{
+          border: 'none',
+          fontSize: '0.95rem',
+          letterSpacing: '0.02em',
+          fontFamily: 'inherit',
+        }}
+      />
+      <CTA text="Join" type="submit" />
+    </form>
   )
 }

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -9,7 +9,7 @@ export default async function AboutSection() {
   const { data: general } = await sanityFetch({ query: GENERAL_QUERY })
 
   return (
-    <section id="about" className="scroll-mt-24 pt-10 pb-[60px]">
+    <section id="about" className="scroll-mt-24 pt-10 pb-[30px]">
       <div
         style={{
           border: '1px solid rgba(255,255,255,0.7)',

--- a/app/components/sections/audio-section.tsx
+++ b/app/components/sections/audio-section.tsx
@@ -40,7 +40,7 @@ export default async function AudioSection() {
   if (!track) return null
 
   return (
-    <section id="music" className="scroll-mt-24 pt-10 pb-[60px]">
+    <section id="music" className="scroll-mt-24 pt-10 pb-[30px]">
       <div
         style={{
           display: 'flex',

--- a/app/components/sections/shows-section.tsx
+++ b/app/components/sections/shows-section.tsx
@@ -1,4 +1,5 @@
 import { sanityFetch } from '@/sanity/lib/live'
+import CTA from '../cta'
 
 type Ticket = { venue: string; url: string }
 
@@ -33,7 +34,7 @@ export default async function ShowsSection() {
   const upcoming: Show[] = (shows ?? []).filter((s: Show) => s.live)
 
   return (
-    <section id="shows" className="scroll-mt-24 pt-10 pb-[60px]">
+    <section id="shows" className="scroll-mt-24 pt-10 pb-[30px]">
       <div style={{ marginBottom: 20 }}>
         <div
           style={{
@@ -52,17 +53,14 @@ export default async function ShowsSection() {
           >
             SHOWS
           </div>
-          <span
-            style={{
-              fontSize: '0.75rem',
-              letterSpacing: '0.2em',
-              color: 'rgba(255,255,255,0.6)',
-            }}
-          >
-            ALL SHOWS →
-          </span>
         </div>
-        <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+        <div
+          style={{
+            height: '1.25rem',
+            overflow: 'hidden',
+            marginTop: '-0.22em',
+          }}
+        >
           <span
             aria-hidden="true"
             style={{
@@ -74,7 +72,7 @@ export default async function ShowsSection() {
               color: 'transparent',
               userSelect: 'none',
               pointerEvents: 'none',
-              marginTop: 1,
+              marginTop: '-0.22em',
               transform: 'scaleY(-1)',
               backgroundImage:
                 'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
@@ -168,20 +166,7 @@ export default async function ShowsSection() {
 
                 {/* Tickets */}
                 {ticketUrl ? (
-                  <a
-                    href={ticketUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    style={{
-                      fontSize: '0.75rem',
-                      letterSpacing: '0.2em',
-                      color: 'rgba(255,255,255,0.7)',
-                      textDecoration: 'none',
-                    }}
-                  >
-                    TICKETS →
-                  </a>
+                  <CTA link={ticketUrl} text="Tickets" external />
                 ) : (
                   <div />
                 )}

--- a/app/components/sections/video-section.tsx
+++ b/app/components/sections/video-section.tsx
@@ -26,7 +26,7 @@ export default async function VideoSection() {
   const rest = list.slice(1)
 
   return (
-    <section id="video" className="scroll-mt-24 pt-10 pb-[60px]">
+    <section id="video" className="scroll-mt-24 pt-10 pb-[30px]">
       <div style={{ marginBottom: 20 }}>
         <div
           style={{
@@ -45,17 +45,14 @@ export default async function VideoSection() {
           >
             VIDEOS
           </div>
-          <span
-            style={{
-              fontSize: '0.75rem',
-              letterSpacing: '0.2em',
-              color: 'rgba(255,255,255,0.6)',
-            }}
-          >
-            ALL VIDEOS →
-          </span>
         </div>
-        <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+        <div
+          style={{
+            height: '1.25rem',
+            overflow: 'hidden',
+            marginTop: '-0.22em',
+          }}
+        >
           <span
             aria-hidden="true"
             style={{
@@ -67,7 +64,7 @@ export default async function VideoSection() {
               color: 'transparent',
               userSelect: 'none',
               pointerEvents: 'none',
-              marginTop: 1,
+              marginTop: '-0.22em',
               transform: 'scaleY(-1)',
               backgroundImage:
                 'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -89,7 +89,13 @@ export default async function SiteFooter() {
           >
             NEWSLETTER
           </div>
-          <div style={{ height: '1.25rem', overflow: 'hidden' }}>
+          <div
+            style={{
+              height: '1.25rem',
+              overflow: 'hidden',
+              marginTop: '-0.22em',
+            }}
+          >
             <span
               aria-hidden="true"
               style={{
@@ -101,7 +107,7 @@ export default async function SiteFooter() {
                 color: 'transparent',
                 userSelect: 'none',
                 pointerEvents: 'none',
-                marginTop: 1,
+                marginTop: '-0.22em',
                 transform: 'scaleY(-1)',
                 backgroundImage:
                   'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
@@ -115,34 +121,21 @@ export default async function SiteFooter() {
         </div>
         <div
           style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-            gap: 36,
-            alignItems: 'start',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            alignItems: 'stretch',
           }}
         >
-          <div>
-            <div
-              style={{
-                fontSize: 'clamp(1.3rem, 3vw, 1.8rem)',
-                fontWeight: 500,
-                letterSpacing: '-0.01em',
-                lineHeight: 1.1,
-                marginBottom: 10,
-              }}
-            >
-              Letters from the studio.
-            </div>
-            <div
-              style={{
-                fontSize: '0.85rem',
-                color: 'rgba(255,255,255,0.6)',
-                lineHeight: 1.5,
-                maxWidth: 360,
-              }}
-            >
-              Mostly quiet. A handful of times a year.
-            </div>
+          <div
+            style={{
+              fontSize: 'clamp(1.3rem, 3vw, 1.8rem)',
+              fontWeight: 500,
+              letterSpacing: '-0.01em',
+              lineHeight: 1.1,
+            }}
+          >
+            Letters from the studio.
           </div>
           <NewsletterForm />
         </div>
@@ -224,6 +217,7 @@ export default async function SiteFooter() {
             textAlign: 'center',
             height: 'clamp(3rem, 10vw, 8rem)',
             overflow: 'hidden',
+            marginTop: '-0.18em',
           }}
         >
           <span
@@ -237,7 +231,7 @@ export default async function SiteFooter() {
               color: 'transparent',
               userSelect: 'none',
               pointerEvents: 'none',
-              marginTop: 2,
+              marginTop: '-0.18em',
               transform: 'scaleY(-1)',
               backgroundImage:
                 'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,11 @@ body {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+::selection {
+  background-color: #ffcee5;
+  color: #0e2795;
+}
+
 h1 {
   font-size: clamp(3.2rem, 11vw, 7.5rem);
   line-height: 0.92;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,7 +64,7 @@ export default async function Home() {
 
       {/* Bio quote */}
       {general?.introShort && (
-        <section className="pt-5 pb-[60px]">
+        <section className="pt-5 pb-[30px]">
           <p
             className="text-gradient-pink-blue m-0"
             style={{


### PR DESCRIPTION
- Redesign newsletter section to single column (remove subtext, collapse grid)
- Replace newsletter submit button with CTA component pill
- Fix reflection effect offsets at all 4 sites (NEWSLETTER, SHOWS, VIDEOS, ADEOLA) to start flush at baseline instead of floating below text
- Add custom ::selection styling (pink background, blue text)
- Remove ALL SHOWS and ALL VIDEOS links from section headers
- Style Tickets button as CTA pill component to match design system
- Reduce section bottom padding from pb-[60px] to pb-[30px] across all sections