### PR TITLE
feat: accessibility hardening, responsive fixes, and design system docs

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,185 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-02T00:00:00Z",
+  "title": "Design System: Adeola",
+  "extensions": {
+    "colorMeta": {
+      "cobalt": {
+        "role": "primary",
+        "displayName": "Deep Cobalt",
+        "canonical": "oklch(27% 0.22 264)",
+        "tonalRamp": ["#050d3d", "#091a6b", "#0e2795", "#1e42c0", "#3d60d8", "#6884e8", "#a0aef2", "#d0d5f8"]
+      },
+      "cobalt-deep": {
+        "role": "primary",
+        "displayName": "Cobalt Deep",
+        "canonical": "oklch(20% 0.18 264)",
+        "tonalRamp": ["#00071a", "#001038", "#002f6d", "#0046a4", "#1460c8", "#4882dc", "#8caaec", "#ccd6f8"]
+      },
+      "near-black": {
+        "role": "neutral",
+        "displayName": "Near-Black",
+        "canonical": "oklch(13% 0.00 0)",
+        "tonalRamp": ["#080808", "#161616", "#282828", "#3c3c3c", "#5a5a5a", "#808080", "#b4b4b4", "#e8e8e8"]
+      },
+      "white": {
+        "role": "neutral",
+        "displayName": "Pure White",
+        "canonical": "oklch(100% 0.00 0)",
+        "tonalRamp": ["#1a1a1a", "#363636", "#5c5c5c", "#848484", "#adadad", "#cfcfcf", "#ebebeb", "#ffffff"]
+      },
+      "off-white": {
+        "role": "neutral",
+        "displayName": "Off-White",
+        "canonical": "oklch(96% 0.005 60)",
+        "tonalRamp": ["#3d3c38", "#6a6860", "#919080", "#b8b6a8", "#d4d2ca", "#e8e6e0", "#f2f0ec", "#f6f6f4"]
+      },
+      "blush": {
+        "role": "secondary",
+        "displayName": "Blush",
+        "canonical": "oklch(88% 0.07 0)",
+        "tonalRamp": ["#6b1535", "#a0294d", "#d44d6e", "#e8738d", "#f4a8bc", "#ffcee5", "#ffe0ed", "#fff0f5"]
+      },
+      "gold-warm": {
+        "role": "tertiary",
+        "displayName": "Gold Warm",
+        "canonical": "oklch(88% 0.13 75)",
+        "tonalRamp": ["#3d2200", "#7a4600", "#b46800", "#d98f00", "#f0b830", "#ffd485", "#ffe8b0", "#fff6e0"]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display Wordmark",
+        "purpose": "The ADEOLA footer wordmark only. One instance per page. Always paired with the Reflection effect."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "The artist name <h1>. One per page. Tight negative tracking. Always uppercase."
+      },
+      "title": {
+        "displayName": "Section Title",
+        "purpose": "Section <h2> labels: SHOWS, VIDEOS, MUSIC, ABOUT, NEWSLETTER. Always all-caps, always paired with Reflection."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Bio copy, modal content, show venue text. Max-width 720px for reading comfort."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Copyright, sublabels (UPCOMING, NEW RELEASE), metadata, form field labels. Wide tracking at small size."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "transition-fast",
+        "value": "200ms ease",
+        "purpose": "Color transitions on nav links and interactive text."
+      },
+      {
+        "name": "transition-medium",
+        "value": "300ms ease",
+        "purpose": "Opacity transitions on images and modal overlays."
+      },
+      {
+        "name": "drawer-slide",
+        "value": "translateX: 200ms ease",
+        "purpose": "Mobile nav drawer slide-in. Paired with opacity transition."
+      }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px", "note": "Audio section stacks to two columns; touch-scale targets confirmed." },
+      { "name": "md", "value": "768px", "note": "Nav switches from hamburger to horizontal links; container padding increases." },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "max", "value": "1440px", "note": "Container max-width cap." }
+    ]
+  },
+  "components": [
+    {
+      "name": "CTA Pill",
+      "kind": "button",
+      "refersTo": "cta-pill",
+      "description": "The only interactive button shape in the system. Used for every action: releases, tickets, contact, submit.",
+      "html": "<button class=\"ds-cta-pill\"><span class=\"ds-cta-pill__icon\"><svg width=\"8\" height=\"9\" viewBox=\"0 0 8 9\" fill=\"none\"><path d=\"M8 4.5L0 9L0 0L8 4.5Z\" fill=\"#161616\"/></svg></span><span>EP OUT NOW</span></button>",
+      "css": ".ds-cta-pill { display: inline-flex; align-items: center; gap: 8px; border-radius: 9999px; border: 0.4px solid rgba(246,246,246,0.4); background: #161616; padding: 8px 16px 8px 8px; font-size: 0.875rem; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #ffffff; cursor: pointer; transition: opacity 200ms ease; min-height: 44px; } .ds-cta-pill:hover { opacity: 0.8; } .ds-cta-pill:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(255,255,255,0.6), 0 0 0 4px #0e2795; } .ds-cta-pill__icon { display: flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; background: #ffffff; flex-shrink: 0; }"
+    },
+    {
+      "name": "Nav Link (Desktop)",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Horizontal desktop navigation link. Active state underlined. Inactive state at white/60.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav__link\" href=\"#\">Music</a><a class=\"ds-nav__link ds-nav__link--active\" href=\"#\">Shows</a><a class=\"ds-nav__link\" href=\"#\">Videos</a></nav>",
+      "css": ".ds-nav { display: flex; align-items: center; gap: 28px; } .ds-nav__link { font-size: 0.875rem; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: rgba(255,255,255,0.6); text-decoration: none; border-radius: 2px; transition: color 200ms ease; padding-bottom: 2px; } .ds-nav__link:hover { color: #ffffff; } .ds-nav__link--active { color: #ffffff; border-bottom: 1px solid #ffffff; } .ds-nav__link:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(255,255,255,0.6); }"
+    },
+    {
+      "name": "Show Row",
+      "kind": "custom",
+      "description": "Three-column grid listing for a live performance. Date | City+Venue | Ticket CTA.",
+      "html": "<div class=\"ds-show-row\"><div class=\"ds-show-row__date\">05.17</div><div class=\"ds-show-row__info\"><div class=\"ds-show-row__city\">HELSINKI</div><div class=\"ds-show-row__venue\">Tavastia Club</div></div><button class=\"ds-cta-pill\"><span class=\"ds-cta-pill__icon\"><svg width=\"8\" height=\"9\" viewBox=\"0 0 8 9\" fill=\"none\"><path d=\"M8 4.5L0 9L0 0L8 4.5Z\" fill=\"#161616\"/></svg></span><span>Tickets</span></button></div>",
+      "css": ".ds-show-row { display: grid; grid-template-columns: 64px 1fr auto; align-items: center; gap: 20px; padding: 20px 0; border-top: 1px solid rgba(255,255,255,0.2); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; } .ds-show-row__date { font-weight: 700; font-size: 1rem; letter-spacing: 0.05em; color: #ffffff; } .ds-show-row__info { display: flex; flex-direction: column; gap: 2px; min-width: 0; } .ds-show-row__city { font-weight: 700; font-size: 1rem; letter-spacing: 0.08em; text-transform: uppercase; color: #ffffff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; } .ds-show-row__venue { font-size: 0.8rem; color: rgba(255,255,255,0.6); }"
+    },
+    {
+      "name": "Video Card",
+      "kind": "card",
+      "description": "Secondary video thumbnail in the grid. 16:10 ratio, semi-transparent play button, bold uppercase caption.",
+      "html": "<a class=\"ds-video-card\" href=\"#\"><div class=\"ds-video-card__thumb\"><div class=\"ds-video-card__overlay\"></div><div class=\"ds-video-card__play\"><svg width=\"10\" height=\"11\" viewBox=\"0 0 8 9\" fill=\"none\"><path d=\"M8 4.5L0 9L0 0L8 4.5Z\" fill=\"white\"/></svg></div></div><div class=\"ds-video-card__caption\"><span class=\"ds-video-card__title\">MUSIC VIDEO</span><span class=\"ds-video-card__meta\">2025</span></div></a>",
+      "css": ".ds-video-card { display: flex; flex-direction: column; gap: 10px; text-decoration: none; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; } .ds-video-card:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(255,255,255,0.6); } .ds-video-card__thumb { aspect-ratio: 16/10; background: rgba(255,255,255,0.08); position: relative; overflow: hidden; } .ds-video-card__overlay { position: absolute; inset: 0; background: linear-gradient(135deg, rgba(255,206,229,0.08), rgba(0,47,109,0.6)); } .ds-video-card__play { position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%); width: 38px; height: 38px; border-radius: 50%; background: rgba(255,255,255,0.18); display: flex; align-items: center; justify-content: center; } .ds-video-card__caption { display: flex; justify-content: space-between; align-items: baseline; } .ds-video-card__title { font-size: 0.78rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: #ffffff; } .ds-video-card__meta { font-size: 0.68rem; color: rgba(255,255,255,0.55); }"
+    },
+    {
+      "name": "About Card",
+      "kind": "card",
+      "description": "The single card in the system. Bordered, transparent, used once for the bio snippet.",
+      "html": "<div class=\"ds-about-card\"><h2 class=\"ds-about-card__heading\">ABOUT</h2><p class=\"ds-about-card__body\">Finnish-Nigerian singer-songwriter crafting intimate R&B from the cobalt deep.</p></div>",
+      "css": ".ds-about-card { border: 1px solid rgba(255,255,255,0.7); border-radius: 12px; padding: clamp(20px, 4vw, 36px); display: grid; gap: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; } .ds-about-card__heading { font-size: clamp(1.4rem, 3vw, 2rem); font-weight: 700; letter-spacing: 0.1em; color: #ffffff; } .ds-about-card__body { font-size: 1rem; font-weight: 500; letter-spacing: 0.005em; line-height: 1.55; color: rgba(255,255,255,0.82); max-width: 720px; }"
+    },
+    {
+      "name": "Section Heading with Reflection",
+      "kind": "custom",
+      "description": "Every section <h2> in the site. The heading plus its mirrored ghost below. Both are encapsulated in the <Reflection> React component.",
+      "html": "<div class=\"ds-section-heading\"><h2 class=\"ds-section-heading__text\">SHOWS</h2><div class=\"ds-section-heading__reflection-wrap\"><span aria-hidden=\"true\" class=\"ds-section-heading__reflection\">SHOWS</span></div></div>",
+      "css": ".ds-section-heading { display: block; } .ds-section-heading__text { font-size: clamp(2rem, 5vw, 3rem); font-weight: 700; letter-spacing: 0.1em; line-height: 1; color: #ffffff; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; } .ds-section-heading__reflection-wrap { height: 1.25rem; overflow: hidden; margin-top: -0.22em; } .ds-section-heading__reflection { display: block; font-size: clamp(2rem, 5vw, 3rem); font-weight: 700; letter-spacing: 0.1em; line-height: 1; color: transparent; transform: scaleY(-1); background-image: linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%); -webkit-background-clip: text; background-clip: text; pointer-events: none; user-select: none; margin-top: -0.22em; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "Warm Signal",
+    "overview": "The cobalt blue is not cold — it is the deep from which warmth rises. Pink and gold are the signal: music bleeding through the surface, emotion transmitted through type. Every design decision asks: does this carry the signal, or does it interfere with it?\n\nThis system is built on a single surface — one unwavering cobalt blue — and trusts that restraint creates more emotional weight than variety. The photography is not placed on the background; it becomes the background, ghosted in via mix-blend-lighten so Adeola inhabits the blue rather than floating above it. Giant display type reflects itself into the void below, vanishing into cobalt like sound fading out. Warmth lives only in the text: the blush-to-deep-blue gradient on emotional copy, gold on numerical accents, the pink text selection state. Everything else is white on cobalt.",
+    "keyCharacteristics": [
+      "Single cobalt surface — no tonal variants, no page background gradients, ever",
+      "System font only — Helvetica Neue is the intentional choice, not a fallback",
+      "Warmth lives in text treatments — blush and gold appear only as accent fills, never as surfaces",
+      "Ghost photography — mix-blend-lighten dissolves the artist into the blue",
+      "Reflection signature — giant display type mirrors itself below, fading into cobalt",
+      "White opacity hierarchy — white/60, /40, /30, /20, /10 replace introducing new greys"
+    ],
+    "rules": [
+      { "name": "The Cobalt-Only Rule", "body": "The page background is always #0e2795. It is not layered, tinted, or broken by sections. If you're adding a background color anywhere, the answer is cobalt.", "section": "colors" },
+      { "name": "The Warmth-Rises Rule", "body": "Blush and gold appear only as gradient fills inside background-clip: text treatments. They are never used as button backgrounds, card tints, border colors, or any other surface. Their rarity is the signal.", "section": "colors" },
+      { "name": "The Opacity Hierarchy", "body": "Muted text and subtle borders are always achieved by reducing white's opacity — rgba(255,255,255,N) — never by introducing a new grey.", "section": "colors" },
+      { "name": "The Caps-for-Identity Rule", "body": "All-caps is reserved for section headers, show titles, identity labels, and product-statement CTAs. Navigation links and conversational CTAs are mixed case.", "section": "typography" },
+      { "name": "The System-Only Rule", "body": "No web fonts. The warmth comes from scale and tracking, not from font personality.", "section": "typography" },
+      { "name": "The No-Shadow Rule", "body": "No box-shadow anywhere. If an element needs to feel elevated, use a border or opacity tint.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use #0e2795 for every page background. The single surface is the identity.",
+      "Do use white opacity variants (white/60, white/40, etc.) for hierarchy — never introduce a new grey.",
+      "Do pair every section <h2> with a <Reflection> component underneath.",
+      "Do use mix-blend-lighten for the hero/artist photograph.",
+      "Do keep the CTA pill shape (fully round) as the only button form.",
+      "Do set min-height: 44px on every interactive element for mobile touch compliance.",
+      "Do use all-caps + wide tracking (0.1em) for section headers, show titles, and identity labels."
+    ],
+    "donts": [
+      "Don't introduce a second background color. One surface.",
+      "Don't add box-shadows anywhere.",
+      "Don't use blush or gold as surface colors, border colors, or button backgrounds.",
+      "Don't load a web font.",
+      "Don't make the site feel like a streaming platform artist profile — no cold metric grids, no algorithm-driven layouts.",
+      "Don't use the EDM festival register — no neon, no aggressive hype copy.",
+      "Don't over-design with competing effects — glassmorphism cards, multi-layer gradients, decorative illustrations.",
+      "Don't add new grey values. Use rgba(255,255,255,N) over cobalt.",
+      "Don't use backdrop-filter: blur() on persistent elements. Reserved for the contact modal overlay only.",
+      "Don't use border-left or border-right as a colored accent stripe."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,248 @@
+---
+name: 'Adeola'
+description: 'Artist portfolio for Finnish-Nigerian singer-songwriter Adeola'
+colors:
+  cobalt: '#0e2795'
+  cobalt-deep: '#002f6d'
+  near-black: '#161616'
+  white: '#ffffff'
+  off-white: '#f6f6f6'
+  blush: '#ffcee5'
+  gold-warm: '#ffd485'
+typography:
+  display:
+    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 'clamp(5rem, 24vw, 22.3125rem)'
+    fontWeight: 700
+    lineHeight: 0.92
+    letterSpacing: '-0.055em'
+  headline:
+    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 'clamp(3.2rem, 11vw, 7.5rem)'
+    fontWeight: 700
+    lineHeight: 0.92
+    letterSpacing: '-0.035em'
+  title:
+    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: 'clamp(2rem, 5vw, 3rem)'
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: '0.1em'
+  body:
+    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: '1rem'
+    fontWeight: 500
+    lineHeight: 1.5
+    letterSpacing: '0.025em'
+  label:
+    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize: '0.75rem'
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: '0.1em'
+rounded:
+  none: '0px'
+  card: '12px'
+  modal: '16px'
+  pill: '9999px'
+spacing:
+  xs: '8px'
+  sm: '16px'
+  md: '28px'
+  lg: '40px'
+  xl: '60px'
+components:
+  cta-pill:
+    backgroundColor: '{colors.near-black}'
+    textColor: '{colors.white}'
+    rounded: '{rounded.pill}'
+    padding: '8px 16px 8px 8px'
+  cta-pill-hover:
+    backgroundColor: '{colors.near-black}'
+    textColor: '{colors.white}'
+    padding: '8px 16px 8px 8px'
+  about-card:
+    backgroundColor: 'transparent'
+    textColor: '{colors.white}'
+    rounded: '{rounded.card}'
+    padding: 'clamp(20px, 4vw, 36px)'
+  contact-modal:
+    backgroundColor: '{colors.cobalt}'
+    textColor: '{colors.white}'
+    rounded: '{rounded.modal}'
+    padding: 'clamp(28px, 5vw, 48px)'
+---
+
+# Design System: Adeola
+
+## 1. Overview: The Warm Signal System
+
+**Creative North Star: "Warm Signal"**
+
+The cobalt blue is not cold — it is the deep from which warmth rises. Pink and gold are the signal: music bleeding through the surface, emotion transmitted through type. Every design decision asks: does this carry the signal, or does it interfere with it?
+
+This system is built on a single surface — one unwavering cobalt blue — and trusts that restraint creates more emotional weight than variety. The photography is not placed on the background; it becomes the background, ghosted in via mix-blend-lighten so Adeola inhabits the blue rather than floating above it. Giant display type reflects itself into the void below, vanishing into cobalt like sound fading out. Warmth lives only in the text: the blush-to-deep-blue gradient on emotional copy, gold on numerical accents, the pink text selection state. Everything else is white on cobalt.
+
+The system explicitly rejects the streaming platform aesthetic (Spotify's cold metric grids, Apple Music's corporate geometry), the EDM festival register (neon, busy layouts, hype overload), and over-designed indie portfolios (competing effects, maximalist decoration). The site speaks of intimacy, not spectacle.
+
+**Key Characteristics:**
+
+- Single cobalt surface — no tonal variants, no page background gradients, ever
+- System font only — Helvetica Neue is the intentional choice, not a fallback
+- Warmth lives in text treatments — blush and gold appear only as accent fills, never as surfaces
+- Ghost photography — `mix-blend-lighten` dissolves the artist into the blue
+- Reflection signature — giant display type mirrors itself below, fading into cobalt
+- White opacity hierarchy — `white/60`, `/40`, `/30`, `/20`, `/10` replace introducing new greys
+
+## 2. Colors: The Cobalt-and-Signal Palette
+
+One surface, three signals. The palette is strict: cobalt holds everything, white reads on it, and blush + gold are reserved for emotional punctuation.
+
+### Primary
+
+- **Deep Cobalt** (`#0e2795`): The only page background. Applied globally and nowhere else as a background — not on cards, not in overlays, not as a tint. The entire site lives on this single surface.
+- **Cobalt Deep** (`#002f6d`): The dark gradient endpoint. Appears only inside gradient text treatments (the bio quote fade-to-deep) and as the modal overlay base mixed with near-black.
+
+### Secondary
+
+- **Blush** (`#ffcee5`): The warm signal. Used as the bright end of the bio quote gradient text and as the browser text-selection background color. Never used as a solid fill on a surface.
+- **Gold Warm** (`#ffd485`): Numerical accent. Appears only on the show count `(N)` typographic numerals as a gradient fill. A single deliberate note of warmth in a field of white.
+
+### Neutral
+
+- **White** (`#ffffff`): Primary foreground. All readable text, borders, and iconography.
+- **Near-Black** (`#161616`): The CTA pill background. The only surface in the system that isn't cobalt.
+- **Off-White** (`#f6f6f6`): Gradient endpoint for the reflection fade effect. Never used as a visible surface color.
+
+### Named Rules
+
+**The Cobalt-Only Rule.** The page background is always `#0e2795`. It is not layered, tinted, or broken by sections. If you're adding a background color anywhere, the answer is cobalt.
+
+**The Warmth-Rises Rule.** Blush and gold appear only as gradient fills inside `background-clip: text` treatments. They are never used as button backgrounds, card tints, border colors, or any other surface. Their rarity is the signal.
+
+**The Opacity Hierarchy.** Muted text and subtle borders are always achieved by reducing white's opacity — `rgba(255,255,255,N)` — never by introducing a new grey. The scale in use: `0.70`, `0.60`, `0.55`, `0.40`, `0.35`, `0.30`, `0.25`, `0.20`, `0.10`, `0.06`, `0.05`.
+
+## 3. Typography: Helvetica as Architecture
+
+**Display / Headline / Title / Body / Label Font:** `'Helvetica Neue', Helvetica, Arial, sans-serif` — system stack, no web fonts loaded.
+
+**Character:** A single typeface at five different scales. The warmth comes from proportion, spacing, and case — not from personality. All-caps with wide tracking for identifiers; tight negative tracking for giants; loose positive tracking for body. The system font choice is a deliberate statement: the design doesn't need a decorative font because the typography itself is the decoration.
+
+### Hierarchy
+
+- **Display** (700, `clamp(5rem, 24vw, 22.3125rem)`, lh 0.92, ls -0.055em): The ADEOLA footer wordmark. Full-width, centered, paired with the reflection effect. One instance only.
+- **Headline** (700, `clamp(3.2rem, 11vw, 7.5rem)`, lh 0.92, ls -0.035em): The artist name `<h1>`. Tight negative tracking, uppercase. One per page.
+- **Title** (700, `clamp(2rem, 5vw, 3rem)`, lh 1, ls +0.1em): Section headings (SHOWS, VIDEOS, MUSIC, ABOUT, NEWSLETTER). Wide positive tracking, always uppercase, always paired with the reflection effect below.
+- **Body** (500, `1rem`, lh 1.5, ls +0.025em): Bio text, description copy, modal content. Capped at `max-width: 720px`. Color is white at 80–85% opacity for long passages.
+- **Label** (700, `0.75rem`, lh 1, ls +0.1em, `uppercase`): Copyright, sublabels (UPCOMING, NEW RELEASE), small metadata. Wide tracking at small size. Color is `white/55` to `white/60`.
+
+### Named Rules
+
+**The Caps-for-Identity Rule.** All-caps is reserved for section headers, show titles, identity labels (SINGER · SONGWRITER), and the CTA when it carries a product statement (EP OUT NOW). Navigation links and conversational CTAs are mixed case (Shows, See all videos). Never use all-caps on body copy.
+
+**The System-Only Rule.** No web fonts. Helvetica Neue ships with macOS and Windows; Arial covers Android and older systems. The type feels intentional because the sizing, tracking, and case do the work — not the face.
+
+## 4. Elevation
+
+This system is flat. There are no box-shadows anywhere in the codebase. Depth is conveyed through three techniques instead:
+
+1. **Opacity layering**: White at reduced opacity (`white/06`, `white/08`, `white/10`) creates subtle surface distinctions without shadows.
+2. **Ghost photography**: The hero image uses `mix-blend-lighten` — not a shadow, but a blending mode that makes the subject part of the cobalt surface rather than above it.
+3. **Bordered cards**: The about section card uses a 1px `rgba(255,255,255,0.70)` border — a bright edge without depth or lift.
+
+The contact modal uses `backdrop-filter: blur(4px)` on its overlay for a scrim effect on open. This is the system's only blur — acceptable because it is user-triggered and functional.
+
+### Named Rules
+
+**The No-Shadow Rule.** No `box-shadow` anywhere. If an element needs to feel elevated, use a border or opacity tint. If that doesn't work, reconsider whether the element needs elevation at all.
+
+## 5. Components
+
+### CTA Pill (Primary Action)
+
+The only button shape in the system. Used for every call-to-action: EP releases, ticket links, contact, newsletter submit.
+
+- **Shape:** Fully round (9999px). Non-negotiable — this is the system's only interactive shape.
+- **Background:** Near-black (`#161616`) — the only non-cobalt surface in the system.
+- **Border:** 0.4px `rgba(246,246,246,0.40)` — ultra-thin, barely-there edge.
+- **Internal structure:** Left-aligned white circle (28px, `bg-white rounded-full`) containing a black play triangle SVG; right side carries the label text.
+- **Padding:** 8px all sides, 16px on the right (`p-2 pr-4`). Minimum height 44px for touch compliance.
+- **Hover:** `opacity: 0.80`. No background shift, no transform.
+- **Focus:** `ring-2 ring-white ring-offset-2 ring-offset-[#0e2795]` — white ring, cobalt offset.
+
+### Navigation
+
+- **Desktop:** Horizontal pill-shaped link row, centered. Links are `white/60`, transition to `white` on hover. Active state adds a 1px `border-b border-white`. Gap of 28px (`gap-7`) between links.
+- **Mobile:** Full-screen cobalt overlay triggered by a 44×44px hamburger. Links render at `text-3xl font-bold uppercase tracking-widest` — large enough to tap comfortably. Active link is full white, inactive links are `white/60`.
+- **Keyboard:** Tab wraps within the mobile drawer. Escape closes. `aria-expanded` on the trigger. Body scroll locks when open.
+
+### Show Row
+
+Three-column grid: date (64px) | city+venue (1fr, `min-width: 0`) | ticket CTA (auto).
+
+- **Dividers:** 1px `rgba(255,255,255,0.20)` hairlines above each row and below the last.
+- **Date:** Bold, 1rem, ls +0.05em.
+- **City:** Bold, `clamp(1rem, 2vw, 1.15rem)`, uppercase, ls +0.08em, truncate with ellipsis on overflow.
+- **Venue:** 0.8rem, `white/60` below the city.
+- **Tickets:** CTA pill in the right column. When no ticket URL: empty div (preserves grid alignment).
+
+### Video Card
+
+Featured video at 16:9 ratio; secondary videos at 16:10 in an `auto-fit minmax(220px, 1fr)` grid.
+
+- **Thumbnail:** `object-cover`, opacity 0.60 (featured) / 0.70 (grid). Overlaid with a subtle `rgba(255,206,229,0.08) → rgba(0,47,109,0.60)` directional gradient on grid items.
+- **Play button:** Centered white circle, `rgba(255,255,255,0.16–0.18)` fill (no blur), containing a white play triangle.
+- **Caption:** Title in bold uppercase (`0.78rem`, ls +0.1em) left-aligned; subtitle in `white/55` right-aligned, same baseline.
+
+### About Card
+
+The only card in the system. Appears once.
+
+- **Border:** 1px `rgba(255,255,255,0.70)` — notably brighter than the standard divider at 0.20–0.25, giving it a framed feeling.
+- **Background:** Transparent — the cobalt surface shows through.
+- **Radius:** 12px.
+- **Padding:** `clamp(20px, 4vw, 36px)` — expands generously on larger screens.
+- **Internal layout:** Heading (`<h2>`) → body paragraph → (optional) CTA.
+
+### Contact Modal
+
+- **Overlay:** `rgba(4,12,40,0.72)` with `blur(4px)`. Click-outside closes.
+- **Panel:** Cobalt background (`#0e2795`), 1px `rgba(255,255,255,0.25)` border, 16px radius, max-width 480px.
+- **Fields:** Borderless inputs on cobalt, 0.5px `rgba(255,255,255,0.35)` bottom border only. Labels are 0.7rem, uppercase, `white/55`, ls +0.22em.
+- **Accessibility:** `role="dialog" aria-modal="true" aria-labelledby="contact-modal-title"`. Focus moves to first input on open; returns to trigger on close.
+
+### Reflection Effect (Signature)
+
+Applied below every section heading and the footer wordmark. Encapsulated in `<Reflection>` component (`app/components/reflection.tsx`).
+
+- **Mechanism:** `aria-hidden="true"` span, `transform: scaleY(-1)`, `background-clip: text`, gradient `linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)`.
+- **Clipping:** Outer wrapper `height: 1.25rem`, `overflow: hidden`, `margin-top: -0.22em` — limits the reflection to a sliver below the text baseline.
+- **Rule:** Every section heading (`<h2>`) gets a reflection. No exceptions. The ADEOLA footer wordmark gets a taller reflection (`clamp(3rem, 10vw, 8rem)` clip height).
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use `#0e2795` for every page background. The single surface is the identity.
+- **Do** use white opacity variants (`white/60`, `white/40`, etc.) for hierarchy — never introduce a new grey.
+- **Do** pair every section `<h2>` with a `<Reflection>` component underneath.
+- **Do** use `mix-blend-lighten` for the hero/artist photograph — the subject inhabits the blue, not floats above it.
+- **Do** use `text-gradient-pink-blue` and `text-gradient-gold` only for their designated contexts: bio quote and show count numerals, respectively.
+- **Do** use all-caps + wide tracking (`0.1em`) for section headers, show titles, and identity labels. Use mixed case for nav links and conversational CTAs.
+- **Do** keep the CTA pill shape (fully round) as the only button form. One shape, everywhere.
+- **Do** add `<Reflection>` to any new section heading added to the page.
+- **Do** use the system font stack (`'Helvetica Neue', Helvetica, Arial, sans-serif`) — no web font imports.
+- **Do** set `min-height: 44px` on every interactive element for mobile touch compliance.
+
+### Don't:
+
+- **Don't** introduce a second background color. Not a darker cobalt section, not a near-black hero band, not a white "light section". One surface.
+- **Don't** add box-shadows. If you feel the need for depth, use a 1px white border at low opacity instead.
+- **Don't** use blush or gold as surface colors, border colors, or button backgrounds. They are signal-in-text only.
+- **Don't** load a web font. The type warmth comes from scale and tracking, not from font personality.
+- **Don't** make the site feel like a streaming platform artist profile — no cold metric grids, no algorithm-driven "similar artists" layouts, no platform chrome.
+- **Don't** use the EDM festival register — no neon, no busy layered layouts, no aggressive countdown timers or hype copy.
+- **Don't** over-design with competing effects — glassmorphism cards, multi-layer gradients, decorative illustrations, or icon libraries. One effect at a time; the reflection is already doing work.
+- **Don't** add new grey values. If something needs to be muted, use `rgba(255,255,255,N)` over cobalt.
+- **Don't** use `backdrop-filter: blur()` on persistent elements (e.g., thumbnails, cards). It is reserved for the contact modal overlay — a user-triggered, transient overlay. Blur on always-visible elements is expensive on mobile and visually noisy.
+- **Don't** use `border-left` or `border-right` as a colored accent stripe. Full borders, opacity tints, or nothing.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,35 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Fans discovering Adeola's music — people who heard a song, saw a clip on social, or were referred and want to go deeper. They arrive on their phone, mid-scroll, looking to connect with the artist. The primary job: feel closer to Adeola and her world (find music, watch videos, catch upcoming shows, sign up for news).
+
+## Product Purpose
+
+adeola.com is the primary digital home for Adeola Ikuesan, Finnish-Nigerian singer-songwriter in the contemporary R&B/pop space. Success looks like a fan landing on the site and immediately feeling the artist's world — then staying long enough to follow a show, listen to a track, or sign up for the newsletter.
+
+## Brand Personality
+
+Atmospheric, warm, welcoming, minimalistic. The design should feel like the music: intimate, considered, and spacious. Warm emotional resonance (pink, gold) lives inside a cool cobalt blue world. Never cold, never clinical, never loud.
+
+## Anti-references
+
+- Generic streaming platform artist profile (Spotify/Apple Music aesthetic — cold, metric-heavy, corporate)
+- EDM festival site — aggressive neon, busy layouts, hype overload
+- Over-designed indie portfolio — too many competing effects, maximalist clutter, design performing over music
+
+## Design Principles
+
+1. **Intimacy over spectacle** — the site invites fans in rather than performing at them
+2. **Typography as identity** — bold display type IS the design; decorative additions dilute it
+3. **Warmth within cool** — pink and gold accents carry emotional weight inside the cobalt world
+4. **Mobile-first presence** — fans arrive on phones; the experience must feel native at thumb-scroll pace
+5. **Less, more felt** — restraint in elements creates more emotional weight for each one present
+
+## Accessibility & Inclusion
+
+WCAG AA minimum. Mobile-primary audience — touch targets, scroll behavior, and legibility on small screens are non-negotiable. Reduced-motion preference is respected globally in CSS.

--- a/app/components/contact-modal.tsx
+++ b/app/components/contact-modal.tsx
@@ -1,19 +1,22 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import CTA from './cta'
 
 export default function ContactModal({
   open,
   onClose,
+  triggerRef,
 }: {
   open: boolean
   onClose: () => void
+  triggerRef?: React.RefObject<HTMLElement | null>
 }) {
   const [sent, setSent] = useState(false)
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [message, setMessage] = useState('')
+  const contentRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!open) return
@@ -24,8 +27,17 @@ export default function ContactModal({
     return () => document.removeEventListener('keydown', onKey)
   }, [open, onClose])
 
+  useEffect(() => {
+    if (!open) return
+    const el = contentRef.current?.querySelector<HTMLElement>(
+      'input, textarea, button'
+    )
+    el?.focus()
+  }, [open])
+
   function handleClose() {
     onClose()
+    triggerRef?.current?.focus()
     setTimeout(() => {
       setSent(false)
       setName('')
@@ -47,14 +59,15 @@ export default function ContactModal({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Contact form"
+      aria-labelledby="contact-modal-title"
       onClick={(e) => {
         if (e.target === e.currentTarget) handleClose()
       }}
       className="fixed inset-0 z-[9000] flex items-center justify-center p-6"
-      style={{ background: 'rgba(4,12,40,0.72)', backdropFilter: 'blur(10px)' }}
+      style={{ background: 'rgba(4,12,40,0.72)', backdropFilter: 'blur(4px)' }}
     >
       <div
+        ref={contentRef}
         className="relative flex w-full max-w-[480px] flex-col gap-7"
         style={{
           background: '#0e2795',
@@ -72,9 +85,12 @@ export default function ContactModal({
           ✕
         </button>
 
-        <p style={{ fontSize: '1.4rem', fontWeight: 700, letterSpacing: '0.06em' }}>
+        <h2
+          id="contact-modal-title"
+          style={{ fontSize: '1.4rem', fontWeight: 700, letterSpacing: '0.06em' }}
+        >
           GET IN TOUCH
-        </p>
+        </h2>
 
         {sent ? (
           <p
@@ -85,7 +101,7 @@ export default function ContactModal({
               paddingBottom: 12,
             }}
           >
-            Thanks — I&apos;ll get back to you.
+            Thanks. I&apos;ll get back to you.
           </p>
         ) : (
           <form
@@ -157,7 +173,7 @@ export default function ContactModal({
                 id="contact-message"
                 required
                 rows={4}
-                placeholder="What&apos;s on your mind?"
+                placeholder="What's on your mind?"
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 className="resize-none bg-transparent py-2.5 text-base text-white outline-none placeholder:text-white/30"

--- a/app/components/cta.tsx
+++ b/app/components/cta.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 const pillClass =
-  'inline-flex items-center gap-2 rounded-full border-[0.4px] border-[rgba(246,246,246,0.4)] bg-[#161616] p-1.5 pr-3.5 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]'
+  'inline-flex items-center gap-2 rounded-full border-[0.4px] border-[rgba(246,246,246,0.4)] bg-[#161616] p-2 pr-4 text-sm text-white transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0e2795]'
 
 function IconCircle() {
   return (

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -17,6 +17,7 @@ export default function Nav() {
   const [activeId, setActiveId] = useState<string | null>(null)
   const [contactOpen, setContactOpen] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
+  const contactTriggerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     const sections = links
@@ -94,7 +95,13 @@ export default function Nav() {
               </a>
             )
           })}
-          <CTA text="Contact" onClick={() => setContactOpen(true)} />
+          <CTA
+            text="Contact"
+            onClick={() => {
+              contactTriggerRef.current = document.activeElement as HTMLElement
+              setContactOpen(true)
+            }}
+          />
         </div>
 
         {/* Mobile hamburger */}
@@ -164,6 +171,7 @@ export default function Nav() {
             <CTA
               text="Contact"
               onClick={() => {
+                contactTriggerRef.current = document.activeElement as HTMLElement
                 setOpen(false)
                 setContactOpen(true)
               }}
@@ -172,7 +180,11 @@ export default function Nav() {
         </div>
       </div>
 
-      <ContactModal open={contactOpen} onClose={() => setContactOpen(false)} />
+      <ContactModal
+        open={contactOpen}
+        onClose={() => setContactOpen(false)}
+        triggerRef={contactTriggerRef}
+      />
     </>
   )
 }

--- a/app/components/newsletter-form.tsx
+++ b/app/components/newsletter-form.tsx
@@ -23,7 +23,7 @@ export default function NewsletterForm() {
           paddingBottom: 10,
         }}
       >
-        Thanks — I&apos;ll be in touch.
+        Thanks. I&apos;ll be in touch.
       </p>
     )
   }
@@ -39,7 +39,11 @@ export default function NewsletterForm() {
         paddingBottom: 8,
       }}
     >
+      <label htmlFor="newsletter-email" className="sr-only">
+        Email address
+      </label>
       <input
+        id="newsletter-email"
         type="email"
         required
         value={email}

--- a/app/components/reflection.tsx
+++ b/app/components/reflection.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  children: string
+  style?: React.CSSProperties
+  clipHeight?: string
+}
+
+export default function Reflection({ children, style, clipHeight = '1.25rem' }: Props) {
+  return (
+    <div style={{ height: clipHeight, overflow: 'hidden', marginTop: '-0.22em' }}>
+      <span aria-hidden="true" className="reflect" style={style}>
+        {children}
+      </span>
+    </div>
+  )
+}

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -1,5 +1,5 @@
 import { sanityFetch } from '@/sanity/lib/live'
-import CTA from '../cta'
+import Reflection from '../reflection'
 
 const GENERAL_QUERY = `*[_type == "general"][0]{
   introShort
@@ -19,31 +19,36 @@ export default async function AboutSection() {
           gap: 18,
         }}
       >
-        <div
-          style={{
-            fontWeight: 700,
-            fontSize: 'clamp(1.4rem, 3vw, 2rem)',
-            letterSpacing: '0.1em',
-          }}
-        >
-          ABOUT
-        </div>
-        <p
-          style={{
-            fontSize: '1rem',
-            fontWeight: 500,
-            letterSpacing: '0.005em',
-            lineHeight: 1.55,
-            margin: 0,
-            color: 'rgba(255,255,255,0.82)',
-            maxWidth: 720,
-          }}
-        >
-          {general?.introShort ?? ''}
-        </p>
         <div>
-          <CTA link="#about" text="Read full bio" />
+          <h2
+            style={{
+              fontWeight: 700,
+              fontSize: 'clamp(1.4rem, 3vw, 2rem)',
+              letterSpacing: '0.1em',
+              lineHeight: 1,
+            }}
+          >
+            ABOUT
+          </h2>
+          <Reflection style={{ fontWeight: 700, fontSize: 'clamp(1.4rem, 3vw, 2rem)', letterSpacing: '0.1em', lineHeight: 1 }}>
+            ABOUT
+          </Reflection>
         </div>
+        {general?.introShort && (
+          <p
+            style={{
+              fontSize: '1rem',
+              fontWeight: 500,
+              letterSpacing: '0.005em',
+              lineHeight: 1.55,
+              margin: 0,
+              color: 'rgba(255,255,255,0.82)',
+              maxWidth: 720,
+            }}
+          >
+            {general.introShort}
+          </p>
+        )}
       </div>
     </section>
   )

--- a/app/components/sections/audio-section.tsx
+++ b/app/components/sections/audio-section.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
 import CTA from '../cta'
+import Reflection from '../reflection'
 
 type Track = {
   _id: string
@@ -41,15 +42,8 @@ export default async function AudioSection() {
 
   return (
     <section id="music" className="scroll-mt-24 pt-10 pb-[30px]">
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'baseline',
-          marginBottom: 8,
-        }}
-      >
-        <div
+      <div style={{ marginBottom: 8 }}>
+        <h2
           style={{
             fontWeight: 700,
             fontSize: 'clamp(2rem, 5vw, 3rem)',
@@ -58,7 +52,10 @@ export default async function AudioSection() {
           }}
         >
           MUSIC
-        </div>
+        </h2>
+        <Reflection style={{ fontWeight: 700, fontSize: 'clamp(2rem, 5vw, 3rem)', letterSpacing: '0.1em', lineHeight: 1 }}>
+          MUSIC
+        </Reflection>
       </div>
       <div
         style={{
@@ -71,14 +68,7 @@ export default async function AudioSection() {
         NEW RELEASE
       </div>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'minmax(160px, 220px) 1fr',
-          gap: 28,
-          alignItems: 'center',
-        }}
-      >
+      <div className="grid grid-cols-1 items-start gap-7 sm:grid-cols-[minmax(160px,220px)_1fr] sm:items-center">
         {/* EP cover */}
         <div
           style={{
@@ -86,6 +76,7 @@ export default async function AudioSection() {
             overflow: 'hidden',
             background: 'rgba(255,255,255,0.06)',
             position: 'relative',
+            maxWidth: 220,
           }}
         >
           {hasAsset(track.coverImage) ? (

--- a/app/components/sections/shows-section.tsx
+++ b/app/components/sections/shows-section.tsx
@@ -1,5 +1,6 @@
 import { sanityFetch } from '@/sanity/lib/live'
 import CTA from '../cta'
+import Reflection from '../reflection'
 
 type Ticket = { venue: string; url: string }
 
@@ -43,7 +44,7 @@ export default async function ShowsSection() {
             alignItems: 'baseline',
           }}
         >
-          <div
+          <h2
             style={{
               fontWeight: 700,
               fontSize: 'clamp(2rem, 5vw, 3rem)',
@@ -52,37 +53,11 @@ export default async function ShowsSection() {
             }}
           >
             SHOWS
-          </div>
+          </h2>
         </div>
-        <div
-          style={{
-            height: '1.25rem',
-            overflow: 'hidden',
-            marginTop: '-0.22em',
-          }}
-        >
-          <span
-            aria-hidden="true"
-            style={{
-              display: 'block',
-              fontWeight: 700,
-              fontSize: 'clamp(2rem, 5vw, 3rem)',
-              letterSpacing: '0.1em',
-              lineHeight: 1,
-              color: 'transparent',
-              userSelect: 'none',
-              pointerEvents: 'none',
-              marginTop: '-0.22em',
-              transform: 'scaleY(-1)',
-              backgroundImage:
-                'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
-              WebkitBackgroundClip: 'text',
-              backgroundClip: 'text',
-            }}
-          >
-            SHOWS
-          </span>
-        </div>
+        <Reflection style={{ fontWeight: 700, fontSize: 'clamp(2rem, 5vw, 3rem)', letterSpacing: '0.1em', lineHeight: 1 }}>
+          SHOWS
+        </Reflection>
       </div>
 
       <div
@@ -146,13 +121,16 @@ export default async function ShowsSection() {
                 </div>
 
                 {/* City + venue */}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
                   <div
                     style={{
                       fontWeight: 700,
                       letterSpacing: '0.08em',
                       fontSize: 'clamp(1rem, 2vw, 1.15rem)',
                       textTransform: 'uppercase',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
                     }}
                   >
                     {show.title}

--- a/app/components/sections/video-section.tsx
+++ b/app/components/sections/video-section.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
 import { urlFor, hasAsset } from '@/sanity/lib/image'
+import Reflection from '../reflection'
 
 type Video = {
   _id: string
@@ -35,7 +36,7 @@ export default async function VideoSection() {
             alignItems: 'baseline',
           }}
         >
-          <div
+          <h2
             style={{
               fontWeight: 700,
               fontSize: 'clamp(2rem, 5vw, 3rem)',
@@ -44,37 +45,11 @@ export default async function VideoSection() {
             }}
           >
             VIDEOS
-          </div>
+          </h2>
         </div>
-        <div
-          style={{
-            height: '1.25rem',
-            overflow: 'hidden',
-            marginTop: '-0.22em',
-          }}
-        >
-          <span
-            aria-hidden="true"
-            style={{
-              display: 'block',
-              fontWeight: 700,
-              fontSize: 'clamp(2rem, 5vw, 3rem)',
-              letterSpacing: '0.1em',
-              lineHeight: 1,
-              color: 'transparent',
-              userSelect: 'none',
-              pointerEvents: 'none',
-              marginTop: '-0.22em',
-              transform: 'scaleY(-1)',
-              backgroundImage:
-                'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
-              WebkitBackgroundClip: 'text',
-              backgroundClip: 'text',
-            }}
-          >
-            VIDEOS
-          </span>
-        </div>
+        <Reflection style={{ fontWeight: 700, fontSize: 'clamp(2rem, 5vw, 3rem)', letterSpacing: '0.1em', lineHeight: 1 }}>
+          VIDEOS
+        </Reflection>
       </div>
 
       {list.length === 0 ? (
@@ -131,8 +106,7 @@ export default async function VideoSection() {
                       width: 68,
                       height: 68,
                       borderRadius: '50%',
-                      background: 'rgba(255,255,255,0.16)',
-                      backdropFilter: 'blur(6px)',
+                      background: 'rgba(255,255,255,0.18)',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { sanityFetch } from '@/sanity/lib/live'
 import NewsletterForm from './newsletter-form'
+import Reflection from './reflection'
 
 type Social = { social: string; url: string }
 type General = { socials?: Social[] }
@@ -79,7 +80,7 @@ export default async function SiteFooter() {
         }}
       >
         <div>
-          <div
+          <h2
             style={{
               fontWeight: 700,
               fontSize: 'clamp(2rem, 5vw, 3rem)',
@@ -88,36 +89,10 @@ export default async function SiteFooter() {
             }}
           >
             NEWSLETTER
-          </div>
-          <div
-            style={{
-              height: '1.25rem',
-              overflow: 'hidden',
-              marginTop: '-0.22em',
-            }}
-          >
-            <span
-              aria-hidden="true"
-              style={{
-                display: 'block',
-                fontWeight: 700,
-                fontSize: 'clamp(2rem, 5vw, 3rem)',
-                letterSpacing: '0.1em',
-                lineHeight: 1,
-                color: 'transparent',
-                userSelect: 'none',
-                pointerEvents: 'none',
-                marginTop: '-0.22em',
-                transform: 'scaleY(-1)',
-                backgroundImage:
-                  'linear-gradient(to top, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 50%)',
-                WebkitBackgroundClip: 'text',
-                backgroundClip: 'text',
-              }}
-            >
-              NEWSLETTER
-            </span>
-          </div>
+          </h2>
+          <Reflection style={{ fontWeight: 700, fontSize: 'clamp(2rem, 5vw, 3rem)', letterSpacing: '0.1em', lineHeight: 1 }}>
+            NEWSLETTER
+          </Reflection>
         </div>
         <div
           style={{
@@ -163,7 +138,7 @@ export default async function SiteFooter() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={s.social}
-                className="flex items-center justify-center text-white transition-colors duration-200 hover:text-white/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className="flex items-center justify-center text-white transition-colors duration-200 hover:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                 style={{ width: 52, height: 52 }}
               >
                 {icon ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -39,9 +39,9 @@
     rgba(246, 246, 246, 0) 100%
   );
   --gradient-reflection: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.2) 0%,
-    rgba(255, 255, 255, 0) 70%
+    to top,
+    rgba(255, 255, 255, 0.25) 0%,
+    rgba(255, 255, 255, 0) 50%
   );
 
   /* Semantic */
@@ -197,6 +197,7 @@ h1 {
 /* Apply to a flipped duplicate element underneath display type.
    Pairs with .display-giant on ADE, SHOWS, ADEOLA wordmarks. */
 .reflect {
+  display: block;
   transform: scaleY(-1);
   background-image: var(--gradient-reflection);
   -webkit-background-clip: text;
@@ -204,5 +205,5 @@ h1 {
   color: transparent;
   pointer-events: none;
   user-select: none;
-  margin-top: 2px;
+  margin-top: -0.22em;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,9 @@ import SmoothScroll from './components/smooth-scroll'
 import { SanityLive } from '@/sanity/lib/live'
 
 export const metadata: Metadata = {
-  title: 'Adeola',
-  description: 'Adeola',
+  title: 'Adeola — Singer · Songwriter',
+  description:
+    'Official site of Adeola Ikuesan — music, shows, videos, and more.',
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

- **Accessibility (WCAG AA):** Promoted all 5 section `<div>` labels to `<h2>` for screen reader heading navigation; added focus management to the contact modal (auto-focus on open, return focus to trigger on close, `aria-labelledby`); added visually-hidden label to newsletter email input; removed broken about-section CTA that linked to its own anchor; improved page metadata
- **Responsive:** Audio section stacks to single column on mobile; shows grid gets `min-width: 0` + `text-overflow: ellipsis` to prevent city name overflow on narrow viewports; CTA touch target raised from 40px → 44px
- **Design system consistency:** Extracted `<Reflection>` component (`app/components/reflection.tsx`) replacing 4× inline duplicates; fixed `--gradient-reflection` CSS variable direction; added missing reflections to MUSIC and ABOUT headings; fixed social link hover opacity to align with token scale
- **Performance:** Removed `backdrop-filter: blur` from the always-visible video play button; reduced contact modal overlay blur from 10px → 4px
- **Polish:** Fixed raw HTML entity in textarea placeholder; replaced em dashes in confirmation copy with periods; guarded empty bio paragraph in about section
- **Design system docs:** Added `PRODUCT.md` (brand strategy, users, anti-references), `DESIGN.md` ("Warm Signal" system spec with tokens, rules, and component docs), and `DESIGN.json` sidecar (tonal ramps, motion tokens, 6 component snippets)

## Test plan

- [ ] Screen reader: headings announce correctly; contact modal focus moves in and returns on close; newsletter input has accessible name
- [ ] Mobile (320px): audio section stacks; shows grid doesn't overflow; all CTAs meet 44px tap target
- [ ] Keyboard: contact modal Escape closes and returns focus to trigger; newsletter submits on Enter
- [ ] Reduced motion: no animations fire with `prefers-reduced-motion: reduce`
- [ ] Empty CMS state: about section renders without blank padded paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)